### PR TITLE
Add persona lookahead operation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -86,10 +86,10 @@
   revision = "68e816d1c783414e79bc65b3994d9ab6b0a722ab"
 
 [[projects]]
+  branch = "master"
   name = "github.com/hashicorp/vault"
   packages = ["api","helper/certutil","helper/compressutil","helper/consts","helper/errutil","helper/jsonutil","helper/logformat","helper/mlock","helper/parseutil","helper/pluginutil","helper/policyutil","helper/salt","helper/strutil","helper/wrapping","logical","logical/framework","logical/plugin","version"]
-  revision = "9afe7330e06e486ee326621624f2077d88bc9511"
-  version = "v0.8.2"
+  revision = "2c6e64226c66b0b7ba751a0845dcfb4ee15e08db"
 
 [[projects]]
   branch = "master"
@@ -196,6 +196,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39ce59dbb95169394fbf9463eb7ce4fbfe51995bd39ecc1ab84fbd9a68120d7c"
+  inputs-digest = "1d1844e8ad0f0cedb4cce8d4aa400cd07b5b3c5b26cb80e473908bdf9879c175"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  version = "0.8.2"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/mgutz/logxi"

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -40,7 +40,8 @@ func pathLogin(b *GcpAuthBackend) *framework.Path {
 		},
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: b.pathLogin,
+			logical.UpdateOperation:           b.pathLogin,
+			logical.PersonaLookaheadOperation: b.pathLogin,
 		},
 
 		HelpSynopsis:    pathLoginHelpSyn,
@@ -223,6 +224,16 @@ func (b *GcpAuthBackend) pathIamLogin(req *logical.Request, loginInfo *gcpLoginI
 	}
 	if serviceAccount == nil {
 		return nil, errors.New("service account is empty")
+	}
+
+	if req.Operation == logical.PersonaLookaheadOperation {
+		return &logical.Response{
+			Auth: &logical.Auth{
+				Persona: &logical.Persona{
+					Name: serviceAccount.UniqueId,
+				},
+			},
+		}, nil
 	}
 
 	// Validate service account can login against role.

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -3,12 +3,13 @@ package gcpauth
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/hashicorp/vault/helper/policyutil"
 	"github.com/hashicorp/vault/helper/strutil"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
-	"strings"
-	"time"
 )
 
 const (
@@ -36,7 +37,6 @@ func pathsRole(b *GcpAuthBackend) []*framework.Path {
 				},
 				"policies": {
 					Type:        framework.TypeString,
-					Default:     "default",
 					Description: "Policies to be set on tokens issued using this role.",
 				},
 				"project_id": {

--- a/plugin/path_role_test.go
+++ b/plugin/path_role_test.go
@@ -2,12 +2,13 @@ package gcpauth
 
 import (
 	"fmt"
-	"github.com/hashicorp/vault/helper/policyutil"
-	"github.com/hashicorp/vault/helper/strutil"
-	"github.com/hashicorp/vault/logical"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/vault/helper/policyutil"
+	"github.com/hashicorp/vault/helper/strutil"
+	"github.com/hashicorp/vault/logical"
 )
 
 func TestRoleIam(t *testing.T) {
@@ -47,7 +48,7 @@ func TestRoleIam(t *testing.T) {
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"role_type":                "iam",
 		"project_id":               os.Getenv("GOOGLE_PROJECT"),
-		"policies":                 []string{"dev", "default"},
+		"policies":                 []string{"dev"},
 		"disable_reauthentication": false,
 		"ttl":              int64(1000),
 		"max_ttl":          int64(2000),
@@ -263,7 +264,7 @@ func testBaseRoleRead(resp *logical.Response, expected map[string]interface{}) e
 
 	expectedVal, ok = expected["policies"]
 	if !ok {
-		expectedVal = []string{"default"}
+		expectedVal = []string{}
 	}
 	if !policyutil.EquivalentPolicies(resp.Data["policies"].([]string), expectedVal.([]string)) {
 		return fmt.Errorf("policies mismatch, expected %v but got %v", expectedVal, resp.Data["policies"])

--- a/vendor/github.com/hashicorp/vault/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/vault/CHANGELOG.md
@@ -1,3 +1,42 @@
+## 0.8.3 (Unreleased)
+
+CHANGES:
+
+ * Policy input/output standardization: For all built-in authentication
+   backends, policies can now be specified as a comma-delimited string or an
+   array if using JSON as API input; on read, policies will be returned as an
+   array; and the `default` policy will not be forcefully added to policies
+   saved in configurations. Please note that the `default` policy will continue
+   to be added to generated tokens, however, rather than backends adding
+   `default` to the given set of input policies (in some cases, adn not in
+   others), the stored set will reflect the user-specified set.
+ * `sign-self-issued` modifies Issuer in generated certificates: In 0.8.2 the
+   endpoint would not modify the Issuer in the generated certificate, leaving
+   the output self-issued. Although theoretically valid, in practice crypto
+   stacks were unhappy validating paths containing such certs. As a result,
+   `sign-self-issued` now encodes the signing CA's Subject DN into the Issuer
+   DN of the generated certificate.
+
+IMPROVEMENTS:
+
+ * mfa (Enterprise): Add the ability to use identity metadata in username format
+ * mfa/okta (Enterprise): Add support for configuring base_url for API calls
+ * secret/pki: `sign-intermediate` will now allow specifying a `ttl` value 
+   longer than the signing CA certificate's NotAfter value. [GH-3325]
+
+BUG FIXES:
+
+ * core: Fix panic while loading leases at startup on ARM processors 
+   [GH-3314]
+ * secret/pki: Fix `sign-self-issued` encoding the wrong subject public key
+   [GH-3325]
+
+## 0.8.2.1 (September 11th, 2017) (Enterprise Only)
+
+BUG FIXES:
+
+ * Fix an issue upgrading to 0.8.2 for Enterprise customers.
+
 ## 0.8.2 (September 5th, 2017)
 
 SECURITY:

--- a/vendor/github.com/hashicorp/vault/helper/policyutil/policyutil.go
+++ b/vendor/github.com/hashicorp/vault/helper/policyutil/policyutil.go
@@ -27,14 +27,14 @@ func ParsePolicies(policiesRaw interface{}) []string {
 	switch policiesRaw.(type) {
 	case string:
 		if policiesRaw.(string) == "" {
-			return []string{"default"}
+			return []string{}
 		}
 		policies = strings.Split(policiesRaw.(string), ",")
 	case []string:
 		policies = policiesRaw.([]string)
 	}
 
-	return SanitizePolicies(policies, true)
+	return SanitizePolicies(policies, false)
 }
 
 // SanitizePolicies performs the common input validation tasks

--- a/vendor/github.com/hashicorp/vault/logical/request.go
+++ b/vendor/github.com/hashicorp/vault/logical/request.go
@@ -174,12 +174,13 @@ type Operation string
 
 const (
 	// The operations below are called per path
-	CreateOperation Operation = "create"
-	ReadOperation             = "read"
-	UpdateOperation           = "update"
-	DeleteOperation           = "delete"
-	ListOperation             = "list"
-	HelpOperation             = "help"
+	CreateOperation           Operation = "create"
+	ReadOperation                       = "read"
+	UpdateOperation                     = "update"
+	DeleteOperation                     = "delete"
+	ListOperation                       = "list"
+	HelpOperation                       = "help"
+	PersonaLookaheadOperation           = "persona-lookahead"
 
 	// The operations below are called globally, the path is less relevant.
 	RevokeOperation   Operation = "revoke"


### PR DESCRIPTION
Also, sync with the rest of the auth backends which as of 0.8.3 will no longer hardcode "default" into stored policies (Vault's core will still add the policy onto generated tokens).

@emilymye Merging this, but if you have any concerns please let me know!