### PR TITLE
Add GCE metadata to inferred IAM auth token.

### DIFF
--- a/plugin/util/iamutil.go
+++ b/plugin/util/iamutil.go
@@ -52,7 +52,7 @@ func ServiceAccountKey(iamClient *iam.Service, keyId, accountId, projectName str
 	keyResource := fmt.Sprintf(serviceAccountKeyTemplate, projectName, accountId, keyId)
 	key, err := iamClient.Projects.ServiceAccounts.Keys.Get(keyResource).PublicKeyType(serviceAccountKeyFileType).Do()
 	if err != nil {
-		return nil, fmt.Errorf("service account key '%s' does not exist", keyResource)
+		return nil, fmt.Errorf("service account key '%s' does not exist: %v", keyResource, err)
 	}
 	return key, nil
 }


### PR DESCRIPTION
Adding so that a) inferred tokens can be rejected for renewal if the role changes to not allow GCE inferrence, and b) to audit GCE instances better.

Also a small fix for an error message in iam utils.