### PR TITLE
Support multiple binds and consistency updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test: fmtcheck generate
 		echo "ERROR: Set TEST to a specific package"; \
 		exit 1; \
 	fi
-	VAULT_ACC=1 go test -tags='$(BUILD_TAGS)' $(TEST) -v $(TESTARGS) -timeout 45m
+	VAULT_ACC=1 go test -tags='$(BUILD_TAGS)' $(TEST) -v $(TESTARGS) -parallel=40 -timeout 45m
 
 # generate runs `go generate` to build the dynamically generated
 # source files.

--- a/plugin/authorizer_client_gcp.go
+++ b/plugin/authorizer_client_gcp.go
@@ -1,0 +1,81 @@
+package gcpauth
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/vault/helper/strutil"
+	compute "google.golang.org/api/compute/v1"
+	iam "google.golang.org/api/iam/v1"
+)
+
+var _ client = (*gcpClient)(nil)
+
+// gcpClient implements client and communicates with the GCP API. It is
+// abstracted as an interface for stubbing during testing. See stubbedClient for
+// more details.
+type gcpClient struct {
+	computeSvc *compute.Service
+	iamSvc     *iam.Service
+}
+
+func (c *gcpClient) InstanceGroups(ctx context.Context, project string, boundInstanceGroups []string) (map[string][]string, error) {
+	// map of zone names to a slice of instance group names in that zone.
+	igz := make(map[string][]string)
+
+	if err := c.computeSvc.InstanceGroups.
+		AggregatedList(project).
+		Fields("items/*/instanceGroups/name").
+		Pages(ctx, func(l *compute.InstanceGroupAggregatedList) error {
+			for k, v := range l.Items {
+				zone, err := zoneFromSelfLink(k)
+				if err != nil {
+					return err
+				}
+
+				for _, g := range v.InstanceGroups {
+					if strutil.StrListContains(boundInstanceGroups, g.Name) {
+						igz[zone] = append(igz[zone], g.Name)
+					}
+				}
+			}
+			return nil
+		}); err != nil {
+		return nil, err
+	}
+
+	return igz, nil
+}
+
+func (c *gcpClient) InstanceGroupContainsInstance(ctx context.Context, project, zone, group, instanceSelfLink string) (bool, error) {
+	var req compute.InstanceGroupsListInstancesRequest
+	resp, err := c.computeSvc.InstanceGroups.
+		ListInstances(project, zone, group, &req).
+		Filter(fmt.Sprintf("instance eq %s", instanceSelfLink)).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return false, err
+	}
+
+	log.Printf("%#v", resp.Items)
+
+	if resp != nil && len(resp.Items) > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (c *gcpClient) ServiceAccount(ctx context.Context, name string) (string, string, error) {
+	account, err := c.iamSvc.Projects.ServiceAccounts.
+		Get(name).
+		Fields("uniqueId", "email").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return "", "", err
+	}
+
+	return account.UniqueId, account.Email, nil
+}

--- a/plugin/authorizer_client_gcp.go
+++ b/plugin/authorizer_client_gcp.go
@@ -3,7 +3,6 @@ package gcpauth
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/vault/helper/strutil"
 	"google.golang.org/api/compute/v1"
@@ -58,8 +57,6 @@ func (c *gcpClient) InstanceGroupContainsInstance(ctx context.Context, project, 
 	if err != nil {
 		return false, err
 	}
-
-	log.Printf("%#v", resp.Items)
 
 	if resp != nil && len(resp.Items) > 0 {
 		return true, nil

--- a/plugin/authorizer_client_gcp.go
+++ b/plugin/authorizer_client_gcp.go
@@ -6,8 +6,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/vault/helper/strutil"
-	compute "google.golang.org/api/compute/v1"
-	iam "google.golang.org/api/iam/v1"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/iam/v1"
 )
 
 var _ client = (*gcpClient)(nil)

--- a/plugin/authorizer_client_stubbed.go
+++ b/plugin/authorizer_client_stubbed.go
@@ -1,0 +1,25 @@
+package gcpauth
+
+import "context"
+
+var _ client = (*stubbedClient)(nil)
+
+// stubbedClient is a simple client to use for testing where the API calls to
+// GCP are "stubbed" instead of hitting the actual API.
+type stubbedClient struct {
+	instanceGroupsByZone          map[string][]string
+	instanceGroupContainsInstance bool
+	saId, saEmail                 string
+}
+
+func (c *stubbedClient) InstanceGroups(_ context.Context, _ string, _ []string) (map[string][]string, error) {
+	return c.instanceGroupsByZone, nil
+}
+
+func (c *stubbedClient) InstanceGroupContainsInstance(_ context.Context, _, _, _, _ string) (bool, error) {
+	return c.instanceGroupContainsInstance, nil
+}
+
+func (c *stubbedClient) ServiceAccount(_ context.Context, _ string) (string, string, error) {
+	return c.saId, c.saEmail, nil
+}

--- a/plugin/authorizer_gce.go
+++ b/plugin/authorizer_gce.go
@@ -1,0 +1,159 @@
+package gcpauth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/vault/helper/strutil"
+)
+
+type client interface {
+	InstanceGroups(context.Context, string, []string) (map[string][]string, error)
+	InstanceGroupContainsInstance(context.Context, string, string, string, string) (bool, error)
+	ServiceAccount(context.Context, string) (string, string, error)
+}
+
+type AuthorizeGCEInput struct {
+	client client
+
+	project        string
+	serviceAccount string
+
+	instanceLabels   map[string]string
+	instanceSelfLink string
+	instanceZone     string
+
+	boundLabels  map[string]string
+	boundRegions []string
+	boundZones   []string
+
+	boundInstanceGroups  []string
+	boundServiceAccounts []string
+}
+
+func AuthorizeGCE(ctx context.Context, i *AuthorizeGCEInput) error {
+	// Verify instance has role labels if labels were set on role.
+	for k, v := range i.boundLabels {
+		if act, ok := i.instanceLabels[k]; !ok || act != v {
+			return fmt.Errorf("instance missing bound label \"%s:%s\"", k, v)
+		}
+	}
+
+	// Parse the zone name from the self-link URI if given.
+	zone, err := zoneFromSelfLink(i.instanceZone)
+	if err != nil {
+		return err
+	}
+
+	// Convert the zone to a region name.
+	region, err := zoneToRegion(zone)
+	if err != nil {
+		return err
+	}
+
+	// Verify the instance is in the zone/region
+	switch {
+	case len(i.boundZones) > 0:
+		if !strutil.StrListContains(i.boundZones, zone) {
+			return fmt.Errorf("instance not in bound zones %q", i.boundZones)
+		}
+	case len(i.boundRegions) > 0:
+		if !strutil.StrListContains(i.boundRegions, region) {
+			return fmt.Errorf("instance not in bound regions %q", i.boundRegions)
+		}
+	}
+
+	// For each bound instance group, verify the group exists and that the
+	// instance is a member of that group.
+	if len(i.boundInstanceGroups) > 0 {
+		igz, err := i.client.InstanceGroups(ctx, i.project, i.boundInstanceGroups)
+		if err != nil {
+			return fmt.Errorf("failed to list instance groups for project %q: %s", i.project, err)
+		}
+
+		// Keep track of whether we've successfully found an instance group of
+		// which this instance is a member, which meets the zonal/regional criteria.
+		found := false
+
+		for _, g := range i.boundInstanceGroups {
+			if found {
+				break
+			}
+
+			var group, zone string
+
+			switch {
+			case len(i.boundZones) > 0:
+				for _, z := range i.boundZones {
+					if groups, ok := igz[z]; ok && len(groups) > 0 {
+						for _, grp := range groups {
+							if grp == g {
+								group = g
+								zone = z
+							}
+						}
+					}
+				}
+				if group == "" {
+					return fmt.Errorf("instance group %q does not exist in zones %q for project %q",
+						g, i.boundZones, i.project)
+				}
+			case len(i.boundRegions) > 0:
+				for _, r := range i.boundRegions {
+					for z, groups := range igz {
+						if strings.HasPrefix(z, r) { // zone is prefixed with region
+							for _, grp := range groups {
+								if grp == g {
+									group = g
+									zone = z
+								}
+							}
+						}
+					}
+				}
+				if group == "" {
+					return fmt.Errorf("instance group %q does not exist in regions %q for project %q",
+						g, i.boundRegions, i.project)
+				}
+			default:
+				return fmt.Errorf("instance group %q is not bound to any zones or regions", g)
+			}
+
+			ok, err := i.client.InstanceGroupContainsInstance(ctx, i.project, zone, group, i.instanceSelfLink)
+			if err != nil {
+				return fmt.Errorf("failed to list instances in instance group %q for project %q: %s",
+					group, i.project, err)
+			}
+
+			if ok {
+				found = true
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("instance is not part of instance groups %q",
+				i.boundInstanceGroups)
+		}
+	}
+
+	// Verify instance is running under one of the allowed service accounts.
+	if len(i.boundServiceAccounts) > 0 {
+		// ServiceAccount wraps a call to the GCP IAM API to get a service account.
+		name := fmt.Sprintf("projects/%s/serviceAccounts/%s", i.project, i.serviceAccount)
+
+		saId, saEmail, err := i.client.ServiceAccount(ctx, name)
+		if err != nil {
+			return fmt.Errorf("could not find service account %q in project %q: %s",
+				i.serviceAccount, i.project, err)
+		}
+
+		if !(strutil.StrListContains(i.boundServiceAccounts, saEmail) ||
+			strutil.StrListContains(i.boundServiceAccounts, saId)) {
+			return fmt.Errorf("service account %q (%q) is not in bound service accounts %q",
+				saId, saEmail, i.boundServiceAccounts)
+		}
+	}
+
+	return nil
+}

--- a/plugin/authorizer_gce_test.go
+++ b/plugin/authorizer_gce_test.go
@@ -1,0 +1,366 @@
+package gcpauth
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestAuthorizeGCE(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		i       *AuthorizeGCEInput
+		err     bool
+		errText string
+	}{
+		// instance labels
+		{
+			"labels_no_match_key",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{},
+				instanceLabels: map[string]string{
+					"foo": "bar",
+				},
+				boundLabels: map[string]string{
+					"foo": "bar",
+					"zip": "zap",
+				},
+			},
+			true,
+			`instance missing bound label "zip:zap"`,
+		},
+		{
+			"labels_no_match_value",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{},
+				instanceLabels: map[string]string{
+					"foo": "bar",
+				},
+				boundLabels: map[string]string{
+					"foo": "zip",
+				},
+			},
+			true,
+			`instance missing bound label "foo:zip"`,
+		},
+
+		// instance zone
+		{
+			"zone_as_self_link_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-east1-a",
+				boundZones:   []string{"us-east1-a", "us-west1-b"},
+			},
+			false,
+			"",
+		},
+		{
+			"zone_as_name_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "us-east1-a",
+				boundZones:   []string{"us-east1-a", "us-west1-b"},
+			},
+			false,
+			"",
+		},
+		{
+			"zone_as_self_link_no_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "https://www.googleapis.com/compute/v1/projects/my-project/zones/eu-west1-a",
+				boundZones:   []string{"us-east1-a", "us-west1-b"},
+			},
+			true,
+			`instance not in bound zones ["us-east1-a" "us-west1-b"]`,
+		},
+		{
+			"zone_as_name_no_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "eu-west1-a",
+				boundZones:   []string{"us-east1-a", "us-west1-b"},
+			},
+			true,
+			`instance not in bound zones ["us-east1-a" "us-west1-b"]`,
+		},
+		{
+			"zone_as_invalid",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "http://google.com/foo/bar",
+				boundZones:   []string{"us-east1-a", "us-west1-b"},
+			},
+			true,
+			`failed to extract zone`,
+		},
+
+		// instance region
+		{
+			"region_as_self_link_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-east1-a",
+				boundRegions: []string{"us-east1", "us-west1"},
+			},
+			false,
+			"",
+		},
+		{
+			"region_as_name_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "us-east1-a",
+				boundRegions: []string{"us-east1", "us-west1"},
+			},
+			false,
+			"",
+		},
+		{
+			"region_as_self_link_no_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "https://www.googleapis.com/compute/v1/projects/my-project/zones/eu-west1-a",
+				boundRegions: []string{"us-east1", "us-west1"},
+			},
+			true,
+			`instance not in bound regions ["us-east1" "us-west1"]`,
+		},
+		{
+			"region_as_name_no_exists",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "eu-west1-a",
+				boundRegions: []string{"us-east1", "us-west1"},
+			},
+			true,
+			`instance not in bound regions ["us-east1" "us-west1"]`,
+		},
+		{
+			"region_as_invalid",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "http://google.com/foo/bar",
+				boundRegions: []string{"us-east1", "us-west1"},
+			},
+			true,
+			`failed to extract zone`,
+		},
+
+		// bound instance groups
+		{
+			"bound_instance_groups_unbound",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone:          map[string][]string{},
+					instanceGroupContainsInstance: true,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+			},
+			true,
+			`instance group "my-instance-group" is not bound to any zones or regions`,
+		},
+		{
+			"bound_instance_groups_empty_bound_zones",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone:          map[string][]string{},
+					instanceGroupContainsInstance: true,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+				boundZones:          []string{"us-east1-a"},
+			},
+			true,
+			`instance group "my-instance-group" does not exist in zones ["us-east1-a"]`,
+		},
+		{
+			"bound_instance_groups_no_exist_bound_zones",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone: map[string][]string{
+						"us-east1-a": []string{"other-instance-group"},
+					},
+					instanceGroupContainsInstance: true,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+				boundZones:          []string{"us-east1-a"},
+			},
+			true,
+			`instance group "my-instance-group" does not exist in zones ["us-east1-a"]`,
+		},
+		{
+			"bound_instance_groups_empty_bound_regions",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone:          map[string][]string{},
+					instanceGroupContainsInstance: true,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+				boundRegions:        []string{"us-east1"},
+			},
+			true,
+			`instance group "my-instance-group" does not exist in regions ["us-east1"]`,
+		},
+		{
+			"bound_instance_groups_no_exist_bound_regions",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone: map[string][]string{
+						"us-east1-a": []string{"other-instance-group"},
+					},
+					instanceGroupContainsInstance: true,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+				boundRegions:        []string{"us-east1"},
+			},
+			true,
+			`instance group "my-instance-group" does not exist in regions ["us-east1"]`,
+		},
+		{
+			"bound_instance_groups_no_contains_instance",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone: map[string][]string{
+						"us-east1-a": []string{"my-instance-group"},
+					},
+					instanceGroupContainsInstance: false,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+				boundZones:          []string{"us-east1-a"},
+			},
+			true,
+			`instance is not part of instance groups ["my-instance-group"]`,
+		},
+
+		// service account
+		{
+			"bound_service_account_no_exist",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					saId:    "foo",
+					saEmail: "foo@bar.com",
+				},
+				serviceAccount:       "foo",
+				instanceZone:         "us-east1-a",
+				boundServiceAccounts: []string{"bar"},
+			},
+			true,
+			`is not in bound service accounts`,
+		},
+		{
+			"bound_service_account_id",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					saId:    "foo",
+					saEmail: "foo@bar.com",
+				},
+				instanceZone:         "us-east1-a",
+				boundServiceAccounts: []string{"foo"},
+			},
+			false,
+			"",
+		},
+		{
+			"bound_service_account_email",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					saId:    "foo",
+					saEmail: "foo@bar.com",
+				},
+				instanceZone:         "us-east1-a",
+				boundServiceAccounts: []string{"foo@bar.com"},
+			},
+			false,
+			"",
+		},
+
+		// full success examples
+		{
+			"success_zone_binding",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "us-east1-a",
+				boundZones:   []string{"us-east1-a"},
+			},
+			false,
+			"",
+		},
+		{
+			"success_region_binding",
+			&AuthorizeGCEInput{
+				client:       &stubbedClient{},
+				instanceZone: "us-east1-a",
+				boundRegions: []string{"us-east1"},
+			},
+			false,
+			"",
+		},
+		{
+			"success_instance_group_zone_binding",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone: map[string][]string{
+						"us-east1-a": []string{"my-instance-group"},
+						"us-east1-b": []string{"my-instance-group", "my-other-group"},
+					},
+					instanceGroupContainsInstance: true,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+				boundZones:          []string{"us-east1-a"},
+			},
+			false,
+			"",
+		},
+		{
+			"success_instance_group_region_binding",
+			&AuthorizeGCEInput{
+				client: &stubbedClient{
+					instanceGroupsByZone: map[string][]string{
+						"us-east1-a": []string{"my-instance-group"},
+						"us-east1-b": []string{"my-instance-group", "my-other-group"},
+					},
+					instanceGroupContainsInstance: true,
+				},
+				instanceZone:        "us-east1-a",
+				boundInstanceGroups: []string{"my-instance-group"},
+				boundRegions:        []string{"us-east1"},
+			},
+			false,
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			err := AuthorizeGCE(ctx, tc.i)
+			if tc.err {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+
+				if !strings.Contains(err.Error(), tc.errText) {
+					t.Errorf("expected %q to contain %q", err.Error(), tc.errText)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -2,7 +2,6 @@ package gcpauth
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -28,6 +27,7 @@ func getTestBackend(t *testing.T) (logical.Backend, logical.Storage) {
 		},
 		StorageView: &logical.InmemStorage{},
 	}
+
 	err := b.Setup(context.Background(), config)
 	if err != nil {
 		t.Fatalf("unable to create backend: %v", err)
@@ -37,20 +37,21 @@ func getTestBackend(t *testing.T) (logical.Backend, logical.Storage) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if _, err := getTestCredentials(); err != nil {
-		t.Fatal(err)
-	}
+	getTestCredentials(t)
 }
 
-func getTestCredentials() (*gcputil.GcpCredentials, error) {
+func getTestCredentials(tb testing.TB) *gcputil.GcpCredentials {
+	tb.Helper()
+
 	credentialsJSON := os.Getenv(googleCredentialsEnv)
 	if credentialsJSON == "" {
-		return nil, fmt.Errorf("%s must be set to JSON string of valid Google credentials file", googleCredentialsEnv)
+		tb.Fatalf("%s must be set to JSON string of valid Google credentials file", googleCredentialsEnv)
 	}
 
 	credentials, err := gcputil.Credentials(credentialsJSON)
 	if err != nil {
-		return nil, fmt.Errorf("valid Google credentials JSON could not be read from %s env variable: %v", googleCredentialsEnv, err)
+		tb.Fatalf("valid Google credentials JSON could not be read from %s env variable: %v", googleCredentialsEnv, err)
 	}
-	return credentials, nil
+
+	return credentials
 }

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -3,6 +3,7 @@ package gcpauth
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -27,3 +28,40 @@ func validateFields(req *logical.Request, data *framework.FieldData) error {
 	return nil
 }
 
+// zoneToRegion converts a zone name to its corresponding region. From
+// https://cloud.google.com/compute/docs/regions-zones/, the FQDN of a zone is
+// always <region>-<zone>. Instead of doing an API call, this function uses
+// string parsing as an opimization.
+//
+// If the zone is a self-link, it is converted into a human name first. If the
+// zone cannot be converted to a region, an error is returned.
+func zoneToRegion(zone string) (string, error) {
+	zone, err := zoneFromSelfLink(zone)
+	if err != nil {
+		return "", err
+	}
+
+	if i := strings.LastIndex(zone, "-"); i > -1 {
+		return zone[0:i], nil
+	}
+	return "", fmt.Errorf("failed to extract region from zone name %q", zone)
+}
+
+// zoneFromSelfLink converts a zone self-link into the human zone name.
+func zoneFromSelfLink(zone string) (string, error) {
+	prefix := "zones/"
+
+	if zone == "" {
+		return "", fmt.Errorf("failed to extract zone from self-link %q", zone)
+	}
+
+	if strings.Contains(zone, "/") {
+		if i := strings.LastIndex(zone, prefix); i > -1 {
+			zone = zone[i+len(prefix) : len(zone)]
+		} else {
+			return "", fmt.Errorf("failed to extract zone from self-link %q", zone)
+		}
+	}
+
+	return zone, nil
+}

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -1,0 +1,29 @@
+package gcpauth
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+// validateFields verifies that no bad arguments were given to the request.
+func validateFields(req *logical.Request, data *framework.FieldData) error {
+	var unknownFields []string
+	for k := range req.Data {
+		if _, ok := data.Schema[k]; !ok {
+			unknownFields = append(unknownFields, k)
+		}
+	}
+
+	if len(unknownFields) > 0 {
+		// Sort since this is a human error
+		sort.Strings(unknownFields)
+
+		return fmt.Errorf("unknown fields: %q", unknownFields)
+	}
+
+	return nil
+}
+

--- a/plugin/helpers_test.go
+++ b/plugin/helpers_test.go
@@ -1,0 +1,106 @@
+package gcpauth
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestZoneToRegion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		zone   string
+		region string
+		err    bool
+	}{
+		{
+			"us-central1-a",
+			"us-central1",
+			false,
+		},
+		{
+			"northamerica-northeast1-c",
+			"northamerica-northeast1",
+			false,
+		},
+		{
+			"europe-west3-c",
+			"europe-west3",
+			false,
+		},
+		{
+			"us",
+			"",
+			true,
+		},
+		{
+			"",
+			"",
+			true,
+		},
+	}
+
+	for i, tc := range cases {
+		tc := tc
+
+		name := fmt.Sprintf("%d_%s_to_%s", i, tc.zone, tc.region)
+		if tc.err {
+			name = fmt.Sprintf("%d_%s_err", i, tc.zone)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := zoneToRegion(tc.zone)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if res != tc.region {
+				t.Errorf("expected %q to convert to %q", tc.zone, tc.region)
+			}
+		})
+	}
+}
+
+func TestZoneFromSelfLink(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		link string
+		zone string
+		err  bool
+	}{
+		{
+			"https://www.googleapis.com/compute/v1/projects/my-project/zones/us-east1-d",
+			"us-east1-d",
+			false,
+		},
+		{
+			"https://www.googleapis.com/compute/v1/projects/my-project/regions/us-east1",
+			"",
+			true,
+		},
+		{
+			"",
+			"",
+			true,
+		},
+	}
+
+	for i, tc := range cases {
+		tc := tc
+		name := fmt.Sprintf("%d", i)
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := zoneFromSelfLink(tc.link)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+			if res != tc.zone {
+				t.Errorf("expected %q to convert to %q", tc.link, tc.zone)
+			}
+		})
+	}
+}

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -80,17 +80,27 @@ func (b *GcpAuthBackend) pathConfigRead(ctx context.Context, req *logical.Reques
 		return nil, nil
 	}
 
-	resp := &logical.Response{
-		Data: map[string]interface{}{
-			"client_email":          config.Credentials.ClientEmail,
-			"client_id":             config.Credentials.ClientId,
-			"private_key_id":        config.Credentials.PrivateKeyId,
-			"project_id":            config.Credentials.ProjectId,
-			"google_certs_endpoint": config.GoogleCertsEndpoint,
-		},
+	resp := make(map[string]interface{})
+
+	if v := config.Credentials.ClientEmail; v != "" {
+		resp["client_email"] = v
+	}
+	if v := config.Credentials.ClientId; v != "" {
+		resp["client_id"] = v
+	}
+	if v := config.Credentials.PrivateKeyId; v != "" {
+		resp["private_key_id"] = v
+	}
+	if v := config.Credentials.ProjectId; v != "" {
+		resp["project_id"] = v
+	}
+	if v := config.GoogleCertsEndpoint; v != "" {
+		resp["google_certs_endpoint"] = v
 	}
 
-	return resp, nil
+	return &logical.Response{
+		Data: resp,
+	}, nil
 }
 
 const confHelpSyn = `Configure credentials used to query the GCP IAM API to verify authenticating service accounts`
@@ -105,8 +115,8 @@ iam AUTH:
 
 // gcpConfig contains all config required for the GCP backend.
 type gcpConfig struct {
-	Credentials         *gcputil.GcpCredentials `json:"credentials" structs:"credentials" mapstructure:"credentials"`
-	GoogleCertsEndpoint string                  `json:"google_certs_endpoint" structs:"google_certs_endpoint" mapstructure:"google_certs_endpoint"`
+	Credentials         *gcputil.GcpCredentials `json:"credentials"`
+	GoogleCertsEndpoint string                  `json:"google_certs_endpoint"`
 }
 
 // Update sets gcpConfig values parsed from the FieldData.

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -38,6 +38,11 @@ If not specified, will use the OAuth2 library default. Useful for testing.`,
 }
 
 func (b *GcpAuthBackend) pathConfigWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Validate we didn't get extraneous fields
+	if err := validateFields(req, data); err != nil {
+		return nil, logical.CodedError(422, err.Error())
+	}
+
 	config, err := b.config(ctx, req.Storage)
 
 	if err != nil {

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -34,11 +34,10 @@ func TestConfig(t *testing.T) {
 	})
 
 	expected := map[string]interface{}{
-		"client_email":          creds["client_email"],
-		"client_id":             creds["client_id"],
-		"private_key_id":        creds["private_key_id"],
-		"project_id":            creds["project_id"],
-		"google_certs_endpoint": "",
+		"client_email":   creds["client_email"],
+		"client_id":      creds["client_id"],
+		"private_key_id": creds["private_key_id"],
+		"project_id":     creds["project_id"],
 	}
 
 	testConfigRead(t, b, reqStorage, expected)
@@ -58,6 +57,8 @@ func TestConfig(t *testing.T) {
 }
 
 func testConfigUpdate(tb testing.TB, b logical.Backend, s logical.Storage, d map[string]interface{}) {
+	tb.Helper()
+
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "config",
@@ -73,6 +74,8 @@ func testConfigUpdate(tb testing.TB, b logical.Backend, s logical.Storage, d map
 }
 
 func testConfigRead(tb testing.TB, b logical.Backend, s logical.Storage, expected map[string]interface{}) {
+	tb.Helper()
+
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
 		Path:      "config",

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -57,7 +57,7 @@ func TestConfig(t *testing.T) {
 	testConfigRead(t, b, reqStorage, expected)
 }
 
-func testConfigUpdate(t *testing.T, b logical.Backend, s logical.Storage, d map[string]interface{}) {
+func testConfigUpdate(tb testing.TB, b logical.Backend, s logical.Storage, d map[string]interface{}) {
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "config",
@@ -65,14 +65,14 @@ func testConfigUpdate(t *testing.T, b logical.Backend, s logical.Storage, d map[
 		Storage:   s,
 	})
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	if resp != nil && resp.IsError() {
-		t.Fatal(resp.Error())
+		tb.Fatal(resp.Error())
 	}
 }
 
-func testConfigRead(t *testing.T, b logical.Backend, s logical.Storage, expected map[string]interface{}) {
+func testConfigRead(tb testing.TB, b logical.Backend, s logical.Storage, expected map[string]interface{}) {
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
 		Path:      "config",
@@ -80,7 +80,7 @@ func testConfigRead(t *testing.T, b logical.Backend, s logical.Storage, expected
 	})
 
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	if resp == nil && expected == nil {
@@ -88,10 +88,10 @@ func testConfigRead(t *testing.T, b logical.Backend, s logical.Storage, expected
 	}
 
 	if resp.IsError() {
-		t.Fatal(resp.Error())
+		tb.Fatal(resp.Error())
 	}
 
 	if !reflect.DeepEqual(resp.Data, expected) {
-		t.Fatalf("config mismatch, expected %v but actually %v", expected, resp.Data)
+		tb.Fatalf("config mismatch, expected %v but actually %v", expected, resp.Data)
 	}
 }

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	t.Parallel()
+
 	b, reqStorage := getTestBackend(t)
 
 	testConfigRead(t, b, reqStorage, nil)

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -52,6 +52,11 @@ GCE identity metadata token ('iam', 'gce' roles).`,
 }
 
 func (b *GcpAuthBackend) pathLogin(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Validate we didn't get extraneous fields
+	if err := validateFields(req, data); err != nil {
+		return nil, logical.CodedError(422, err.Error())
+	}
+
 	loginInfo, err := b.parseAndValidateJwt(ctx, req, data)
 	if err != nil {
 		return logical.ErrorResponse(err.Error()), nil

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -432,7 +432,7 @@ func (b *GcpAuthBackend) pathGceLogin(ctx context.Context, req *logical.Request,
 			metadata.ProjectId, metadata.Zone, metadata.InstanceName, err)), nil
 	}
 
-	if err := b.authorizeGCEInstance(ctx, instance, req.Storage, role, metadata.Zone, loginInfo.ServiceAccountId); err != nil {
+	if err := b.authorizeGCEInstance(ctx, instance, req.Storage, role, loginInfo.ServiceAccountId); err != nil {
 		return logical.ErrorResponse(err.Error()), nil
 	}
 
@@ -513,7 +513,7 @@ func (b *GcpAuthBackend) pathGceRenew(ctx context.Context, req *logical.Request,
 	if !ok {
 		return errors.New("invalid auth metadata: service_account_id not found")
 	}
-	if err := b.authorizeGCEInstance(ctx, instance, req.Storage, role, meta.Zone, serviceAccountId); err != nil {
+	if err := b.authorizeGCEInstance(ctx, instance, req.Storage, role, serviceAccountId); err != nil {
 		return fmt.Errorf("could not renew token for role %s: %v", roleName, err)
 	}
 
@@ -567,104 +567,39 @@ func getInstanceMetadataFromAuth(authMetadata map[string]string) (*gcputil.GCEId
 	return meta, nil
 }
 
-// validateGCEInstance returns an error if the given GCE instance is not authorized for the role.
-func (b *GcpAuthBackend) authorizeGCEInstance(ctx context.Context, instance *compute.Instance, s logical.Storage, role *gcpRole, zone, serviceAccountId string) error {
-	gceClient, err := b.GCE(ctx, s)
+// authorizeGCEInstance returns an error if the given GCE instance is not
+// authorized for the role.
+func (b *GcpAuthBackend) authorizeGCEInstance(ctx context.Context, instance *compute.Instance, s logical.Storage, role *gcpRole, serviceAccountId string) error {
+	computeSvc, err := b.GCE(ctx, s)
 	if err != nil {
 		return err
 	}
 
-	// Verify instance has role labels if labels were set on role.
-	for k, expectedV := range role.BoundLabels {
-		actualV, ok := instance.Labels[k]
-		if !ok || actualV != expectedV {
-			return fmt.Errorf("role label '%s:%s' not found on GCE instance", k, expectedV)
-		}
+	iamSvc, err := b.IAM(ctx, s)
+	if err != nil {
+		return err
 	}
 
-	// Verify that instance is in zone or region if given.
-	if len(role.BoundZone) > 0 {
-		if !compareResourceNameOrSelfLink(role.BoundZone, instance.Zone, "zones") {
-			return fmt.Errorf("instance zone %s is not role zone '%s'", instance.Zone, role.BoundZone)
-		}
-	} else if len(role.BoundRegion) > 0 {
-		zone, err := gceClient.Zones.Get(role.ProjectId, zone).Do()
-		if err != nil {
-			return fmt.Errorf("could not verify instance zone '%s' is available for project '%s': %v", zone.Name, role.ProjectId, err)
-		}
-		if !compareResourceNameOrSelfLink(role.BoundRegion, zone.Region, "regions") {
-			return fmt.Errorf("instance zone %s is not in role region '%s'", zone.Name, role.BoundRegion)
-		}
-	}
+	return AuthorizeGCE(ctx, &AuthorizeGCEInput{
+		client: &gcpClient{
+			computeSvc: computeSvc,
+			iamSvc:     iamSvc,
+		},
 
-	// If instance group is given, verify group exists and that instance is in group.
-	if len(role.BoundInstanceGroup) > 0 {
-		var group *compute.InstanceGroup
-		var err error
+		project:        role.ProjectId,
+		serviceAccount: serviceAccountId,
 
-		// Check if group should be zonal or regional.
-		if len(role.BoundZone) > 0 {
-			group, err = gceClient.InstanceGroups.Get(role.ProjectId, role.BoundZone, role.BoundInstanceGroup).Do()
-			if err != nil {
-				return fmt.Errorf("could not find role instance group %s (project %s, zone %s)", role.BoundInstanceGroup, role.ProjectId, role.BoundZone)
-			}
-		} else if len(role.BoundRegion) > 0 {
-			group, err = gceClient.RegionInstanceGroups.Get(role.ProjectId, role.BoundRegion, role.BoundInstanceGroup).Do()
-			if err != nil {
-				return fmt.Errorf("could not find role instance group %s (project %s, region %s)", role.BoundInstanceGroup, role.ProjectId, role.BoundRegion)
-			}
-		} else {
-			return errors.New("expected zone or region to be set for GCE role '%s' with instance group")
-		}
+		instanceLabels:   instance.Labels,
+		instanceSelfLink: instance.SelfLink,
+		instanceZone:     instance.Zone,
 
-		// Verify instance group contains authenticating instance.
-		instanceIdFilter := fmt.Sprintf("instance eq %s", instance.SelfLink)
-		listInstanceReq := &compute.InstanceGroupsListInstancesRequest{}
-		listResp, err := gceClient.InstanceGroups.ListInstances(role.ProjectId, role.BoundZone, group.Name, listInstanceReq).Filter(instanceIdFilter).Do()
-		if err != nil {
-			return fmt.Errorf("could not confirm instance %s is part of instance group %s: %s", instance.Name, role.BoundInstanceGroup, err)
-		}
+		boundLabels:  role.BoundLabels,
+		boundRegions: role.BoundRegions,
+		boundZones:   role.BoundZones,
 
-		if len(listResp.Items) == 0 {
-			return fmt.Errorf("instance %s is not part of instance group %s", instance.Name, role.BoundInstanceGroup)
-		}
-
-	}
-
-	// Verify instance is running under one of the allowed service accounts.
-	if len(role.BoundServiceAccounts) > 0 {
-		iamClient, err := b.IAM(ctx, s)
-		if err != nil {
-			return err
-		}
-
-		serviceAccount, err := gcputil.ServiceAccount(iamClient, &gcputil.ServiceAccountId{
-			Project:   role.ProjectId,
-			EmailOrId: serviceAccountId,
-		})
-		if err != nil {
-			return fmt.Errorf("could not find service account with id '%s': %v", serviceAccountId, err)
-		}
-
-		if !(strutil.StrListContains(role.BoundServiceAccounts, serviceAccount.Email) ||
-			strutil.StrListContains(role.BoundServiceAccounts, serviceAccount.UniqueId)) {
-			return fmt.Errorf("GCE instance's service account email (%s) or id (%s) not found in role service accounts: %v",
-				serviceAccount.Email, serviceAccount.UniqueId, role.BoundServiceAccounts)
-		}
-	}
-
-	return nil
-}
-
-func compareResourceNameOrSelfLink(expected, actual, collectionId string) bool {
-	sep := fmt.Sprintf("%s/", collectionId)
-	if strings.Contains(expected, sep) {
-		return expected == actual
-	}
-
-	actTkns := strings.SplitAfter(actual, sep)
-	actualName := actTkns[len(actTkns)-1]
-	return expected == actualName
+		boundInstanceGroups:  role.BoundInstanceGroups,
+		boundServiceAccounts: role.BoundServiceAccounts,
+	})
 }
 
 const pathLoginHelpSyn = `Authenticates Google Cloud Platform entities with Vault.`

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -23,6 +23,8 @@ const (
 )
 
 func TestLoginIam(t *testing.T) {
+	t.Parallel()
+
 	b, reqStorage := getTestBackend(t)
 
 	creds, err := getTestCredentials()
@@ -71,6 +73,8 @@ func TestLoginIam(t *testing.T) {
 }
 
 func TestLoginIamWildcard(t *testing.T) {
+	t.Parallel()
+
 	b, reqStorage := getTestBackend(t)
 
 	creds, err := getTestCredentials()
@@ -118,6 +122,8 @@ func TestLoginIamWildcard(t *testing.T) {
 // TestLoginIam_UnauthorizedRole checks that we return an error response
 // if the user attempts to login against a role it is not authorized for.
 func TestLoginIam_UnauthorizedRole(t *testing.T) {
+	t.Parallel()
+
 	b, reqStorage := getTestBackend(t)
 
 	creds, err := getTestCredentials()
@@ -155,6 +161,8 @@ func TestLoginIam_UnauthorizedRole(t *testing.T) {
 
 // TestLoginIam_MissingRole checks that we return an error response if role is not provided.
 func TestLoginIam_MissingRole(t *testing.T) {
+	t.Parallel()
+
 	b, reqStorage := getTestBackend(t)
 
 	creds, err := getTestCredentials()
@@ -182,6 +190,8 @@ func TestLoginIam_MissingRole(t *testing.T) {
 
 // TestLoginIam_ExpiredJwt checks that we return an error response for an expired JWT.
 func TestLoginIam_ExpiredJwt(t *testing.T) {
+	t.Parallel()
+
 	b, reqStorage := getTestBackend(t)
 
 	creds, err := getTestCredentials()
@@ -212,6 +222,8 @@ func TestLoginIam_ExpiredJwt(t *testing.T) {
 
 // TestLoginIam_JwtExpiresLate checks that we return an error response for an expired JWT.
 func TestLoginIam_JwtExpiresTooLate(t *testing.T) {
+	t.Parallel()
+
 	b, reqStorage := getTestBackend(t)
 
 	creds, err := getTestCredentials()

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -27,10 +27,7 @@ func TestLoginIam(t *testing.T) {
 
 	b, reqStorage := getTestBackend(t)
 
-	creds, err := getTestCredentials()
-	if err != nil {
-		t.Fatal(err)
-	}
+	creds := getTestCredentials(t)
 
 	testConfigUpdate(t, b, reqStorage, map[string]interface{}{
 		"credentials": os.Getenv(googleCredentialsEnv),
@@ -77,10 +74,7 @@ func TestLoginIamWildcard(t *testing.T) {
 
 	b, reqStorage := getTestBackend(t)
 
-	creds, err := getTestCredentials()
-	if err != nil {
-		t.Fatal(err)
-	}
+	creds := getTestCredentials(t)
 
 	testConfigUpdate(t, b, reqStorage, map[string]interface{}{
 		"credentials": os.Getenv(googleCredentialsEnv),
@@ -126,10 +120,7 @@ func TestLoginIam_UnauthorizedRole(t *testing.T) {
 
 	b, reqStorage := getTestBackend(t)
 
-	creds, err := getTestCredentials()
-	if err != nil {
-		t.Fatal(err)
-	}
+	creds := getTestCredentials(t)
 
 	roleName := "testrolenologin"
 
@@ -165,10 +156,7 @@ func TestLoginIam_MissingRole(t *testing.T) {
 
 	b, reqStorage := getTestBackend(t)
 
-	creds, err := getTestCredentials()
-	if err != nil {
-		t.Fatal(err)
-	}
+	creds := getTestCredentials(t)
 
 	roleName := "doesnotexist"
 
@@ -194,10 +182,7 @@ func TestLoginIam_ExpiredJwt(t *testing.T) {
 
 	b, reqStorage := getTestBackend(t)
 
-	creds, err := getTestCredentials()
-	if err != nil {
-		t.Fatal(err)
-	}
+	creds := getTestCredentials(t)
 
 	roleName := "testrole"
 	testRoleCreate(t, b, reqStorage, map[string]interface{}{
@@ -226,10 +211,7 @@ func TestLoginIam_JwtExpiresTooLate(t *testing.T) {
 
 	b, reqStorage := getTestBackend(t)
 
-	creds, err := getTestCredentials()
-	if err != nil {
-		t.Fatal(err)
-	}
+	creds := getTestCredentials(t)
 
 	roleName := "testrole"
 

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -198,7 +198,6 @@ func TestLoginIam_ExpiredJwt(t *testing.T) {
 	jwtVal := createExpiredIamToken(t, roleName, creds)
 	loginData := map[string]interface{}{
 		"role": roleName,
-		"kid":  creds.PrivateKeyId,
 		"jwt":  jwtVal,
 	}
 

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -38,7 +38,7 @@ const (
 	maxJwtExpMaxMinutes int = 60
 )
 
-var baseRoleFieldSchema map[string]*framework.FieldSchema = map[string]*framework.FieldSchema{
+var baseRoleFieldSchema = map[string]*framework.FieldSchema{
 	"name": {
 		Type:        framework.TypeString,
 		Description: "Name of the role.",
@@ -89,7 +89,7 @@ var baseRoleFieldSchema map[string]*framework.FieldSchema = map[string]*framewor
 	},
 }
 
-var iamOnlyFieldSchema map[string]*framework.FieldSchema = map[string]*framework.FieldSchema{
+var iamOnlyFieldSchema = map[string]*framework.FieldSchema{
 	"max_jwt_exp": {
 		Type:        framework.TypeDurationSecond,
 		Default:     defaultIamMaxJwtExpMinutes * 60,
@@ -102,7 +102,7 @@ var iamOnlyFieldSchema map[string]*framework.FieldSchema = map[string]*framework
 	},
 }
 
-var gceOnlyFieldSchema map[string]*framework.FieldSchema = map[string]*framework.FieldSchema{
+var gceOnlyFieldSchema = map[string]*framework.FieldSchema{
 	"bound_zone": {
 		Type: framework.TypeString,
 		Description: `

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -293,6 +293,11 @@ func (b *GcpAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 }
 
 func (b *GcpAuthBackend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Validate we didn't get extraneous fields
+	if err := validateFields(req, data); err != nil {
+		return nil, logical.CodedError(422, err.Error())
+	}
+
 	name := strings.ToLower(data.Get("name").(string))
 	if name == "" {
 		return logical.ErrorResponse(errEmptyRoleName), nil
@@ -332,6 +337,11 @@ const pathListRolesHelpSyn = `Lists all the roles that are registered with Vault
 const pathListRolesHelpDesc = `Lists all roles under the GCP backends by name.`
 
 func (b *GcpAuthBackend) pathRoleEditIamServiceAccounts(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Validate we didn't get extraneous fields
+	if err := validateFields(req, data); err != nil {
+		return nil, logical.CodedError(422, err.Error())
+	}
+
 	roleName := data.Get("name").(string)
 	if roleName == "" {
 		return logical.ErrorResponse(errEmptyRoleName), nil
@@ -382,6 +392,11 @@ func editStringValues(initial []string, toAdd []string, toRemove []string) []str
 }
 
 func (b *GcpAuthBackend) pathRoleEditGceLabels(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	// Validate we didn't get extraneous fields
+	if err := validateFields(req, data); err != nil {
+		return nil, logical.CodedError(422, err.Error())
+	}
+
 	roleName := data.Get("name").(string)
 	if roleName == "" {
 		return logical.ErrorResponse(errEmptyRoleName), nil

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -475,6 +475,9 @@ func (b *GcpAuthBackend) pathRoleEditGceLabels(ctx context.Context, req *logical
 		return logical.ErrorResponse(fmt.Sprintf("given invalid labels to add: %q", invalidLabels)), nil
 	}
 	for k, v := range labelsToAdd {
+		if role.BoundLabels == nil {
+			role.BoundLabels = make(map[string]string, len(labelsToAdd))
+		}
 		role.BoundLabels[k] = v
 	}
 


### PR DESCRIPTION
This PR does a few things, primarily because I had to re-arrange some things to fix GH-27.

1. **Parallelize tests** - the tests now run in parallel. On the plane last night, they ran in ~8s. Today they are running at ~2s on my home Internet. That's a 5000% decrease in test time 😄! I had to add a few helpers to make sure tests wouldn't step on each other.

1. **Support multiple bindings for region, zone, and instance group** - this fixes GH-27 and provides users the ability to bind to multiple regions, zones, and/or instance groups instead of a single one. If a GCE instance exists in any of the given values, it will authenticate successfully. 

    Given the existing structure of the backend, it was very difficult to test this new logic in an independent way. I built an "authenticator" interface that makes the GCP API calls. For testing, those API calls can be stubbed with arbitrary values to test exclusively the logic. There's now a test for every edge case using these stubbed values that run very quickly to test our logic.

    The old schema is preserved and automatically upgraded the first time a role is accessed. This is inline with the recommendation from the Vault team on how to handle such upgrades. 

1. **Warning passthrough** - theres now a way to pass warnings up from the helper methods, which is helpful during decoding, etc.

1. **Validate input fields** - this is something Vault is doing sporadically, but I added it here everywhere. Nothing is more frustrating than when you accidentally mistype a field (like `vault write auth/gcp/config cradentials=...`) and Vault happily accepts that. Fields that don't match the schema will now inform the user of their error, hopefully saving valuable debugging time.

1. **Reduce the number of API calls** - there are some optimizations to reduce the number of API calls, including server-side filter and client-side string parsing. For example, given a zone, we can **always** calculate the region from the zone using string parsing; we don't have to incur an API. The zone/regions spec specifically documents this format, so we are okay to use it. On average, this saves two API calls per (GCE) authentication.

🚧 This will require a docs update in the main Vault repo. I can take on that work once we are close to merging this.