### PR TITLE
Rename gcpRole struct field from "RoleType" to "Type", to align with the input

### DIFF
--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -289,7 +289,7 @@ func (b *GcpAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 	resp := make(map[string]interface{})
 
 	if role.RoleType != "" {
-		resp["role_type"] = role.RoleType
+		resp["role"] = role.RoleType
 	}
 	if role.ProjectId != "" {
 		resp["project_id"] = role.ProjectId


### PR DESCRIPTION
This change renames the gcpRole struct field "RoleType" to "Type", which aligns the returned config schema to the input schema and eliminates some language redundancy

e.g. `"type": "iam"` is used to create/configure the role, meanwhile reading a role's configuration returns `"role_type": "iam`

The schema mismatch is problematic when using a vault configuration management tool as the returned result always differs from the desired state.

