### PR TITLE
Fix role type response key and tests

### DIFF
--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -40,8 +40,8 @@ func TestLoginIam(t *testing.T) {
 		"policies":               "dev, prod",
 		"project_id":             creds.ProjectId,
 		"bound_service_accounts": creds.ClientEmail,
-		"ttl":     1800,
-		"max_ttl": 1800,
+		"ttl":                    1800,
+		"max_ttl":                1800,
 	})
 
 	// Have token expire within 5 minutes of max JWT exp

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -289,7 +289,7 @@ func (b *GcpAuthBackend) pathRoleRead(ctx context.Context, req *logical.Request,
 	resp := make(map[string]interface{})
 
 	if role.RoleType != "" {
-		resp["role"] = role.RoleType
+		resp["type"] = role.RoleType
 	}
 	if role.ProjectId != "" {
 		resp["project_id"] = role.ProjectId

--- a/plugin/path_role_test.go
+++ b/plugin/path_role_test.go
@@ -52,7 +52,7 @@ func TestRoleUpdateIam(t *testing.T) {
 	})
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"name":                   roleName,
-		"role_type":              iamRoleType,
+		"type":                   iamRoleType,
 		"project_id":             projectId,
 		"bound_service_accounts": serviceAccounts,
 	})
@@ -70,7 +70,7 @@ func TestRoleUpdateIam(t *testing.T) {
 	})
 
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
-		"role_type":              iamRoleType,
+		"type":                   iamRoleType,
 		"project_id":             projectId,
 		"policies":               []string{"dev"},
 		"ttl":                    time.Duration(1000),
@@ -109,7 +109,7 @@ func TestRoleIam_Wildcard(t *testing.T) {
 	})
 
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
-		"role_type":              iamRoleType,
+		"type":                   iamRoleType,
 		"project_id":             projectId,
 		"bound_service_accounts": serviceAccounts,
 	})
@@ -131,7 +131,7 @@ func TestRoleIam_EditServiceAccounts(t *testing.T) {
 	}
 	expectedRole := map[string]interface{}{
 		"name":                   roleName,
-		"role_type":              iamRoleType,
+		"type":                   iamRoleType,
 		"project_id":             projectId,
 		"bound_service_accounts": initial,
 	}
@@ -192,8 +192,8 @@ func TestRoleIam_MissingRequiredArgs(t *testing.T) {
 
 	// empty project
 	testRoleCreateError(t, b, reqStorage, map[string]interface{}{
-		"name": roleName,
-		"type": iamRoleType,
+		"name":                   roleName,
+		"type":                   iamRoleType,
 		"bound_service_accounts": "aserviceaccountid",
 	}, []string{errEmptyProjectId})
 }
@@ -238,7 +238,7 @@ func TestRoleGce(t *testing.T) {
 	})
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"name":                   roleName,
-		"role_type":              gceRoleType,
+		"type":                   gceRoleType,
 		"project_id":             projectId,
 		"bound_service_accounts": []string{},
 	})
@@ -258,7 +258,7 @@ func TestRoleGce(t *testing.T) {
 	})
 
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
-		"role_type":     gceRoleType,
+		"type":          gceRoleType,
 		"project_id":    projectId,
 		"policies":      []string{"dev"},
 		"ttl":           time.Duration(1000),
@@ -294,7 +294,7 @@ func TestRoleGce_EditLabels(t *testing.T) {
 	})
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"name":         roleName,
-		"role_type":    gceRoleType,
+		"type":         gceRoleType,
 		"project_id":   projectId,
 		"bound_labels": labels,
 	})
@@ -307,7 +307,7 @@ func TestRoleGce_EditLabels(t *testing.T) {
 	labels["toAdd"] = "value"
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"name":         roleName,
-		"role_type":    gceRoleType,
+		"type":         gceRoleType,
 		"project_id":   projectId,
 		"bound_labels": labels,
 	})
@@ -322,7 +322,7 @@ func TestRoleGce_EditLabels(t *testing.T) {
 	delete(labels, "toAdd")
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"name":         roleName,
-		"role_type":    gceRoleType,
+		"type":         gceRoleType,
 		"project_id":   projectId,
 		"bound_labels": labels,
 	})
@@ -351,7 +351,7 @@ func TestRoleGce_DeprecatedFields(t *testing.T) {
 		// Ensure it's the new fields
 		testRoleRead(t, b, storage, roleName, map[string]interface{}{
 			"name":                  roleName,
-			"role_type":             gceRoleType,
+			"type":                  gceRoleType,
 			"project_id":            projectId,
 			"bound_regions":         []string{"us-east1"},
 			"bound_zones":           []string{"us-east1-a"},
@@ -382,7 +382,7 @@ func TestRoleGce_DeprecatedFields(t *testing.T) {
 		// Read the data force an upgrade
 		testRoleRead(t, b, storage, roleName, map[string]interface{}{
 			"name":                  roleName,
-			"role_type":             gceRoleType,
+			"type":                  gceRoleType,
 			"project_id":            projectId,
 			"bound_regions":         []string{"us-east1"},
 			"bound_zones":           []string{"us-east1-a"},
@@ -440,8 +440,8 @@ func TestRole_MissingRequiredArgs(t *testing.T) {
 
 	// empty project
 	testRoleCreateError(t, b, reqStorage, map[string]interface{}{
-		"name": roleName,
-		"type": iamRoleType,
+		"name":                   roleName,
+		"type":                   iamRoleType,
 		"bound_service_accounts": "aserviceaccountid",
 	}, []string{errEmptyProjectId})
 }
@@ -612,9 +612,9 @@ func checkData(resp *logical.Response, expected map[string]interface{}, expected
 }
 
 func testBaseRoleRead(resp *logical.Response, expected map[string]interface{}) error {
-	expectedVal, ok := expected["role_type"]
-	if ok && resp.Data["role_type"].(string) != expectedVal.(string) {
-		return fmt.Errorf("role_type mismatch, expected %s but got %s", expectedVal, resp.Data["role_type"])
+	expectedVal, ok := expected["type"]
+	if ok && resp.Data["type"].(string) != expectedVal.(string) {
+		return fmt.Errorf("role type mismatch, expected %s but got %s", expectedVal, resp.Data["type"])
 	}
 
 	expectedVal, ok = expected["project_id"]


### PR DESCRIPTION
@emilymye amongst the changes, I noticed the reading of a role would return the value `role` instead of the intended value of `type`. I've fixed this and updated the tests to support this new value.

