### PR TITLE
Cache clients to improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ ui/coverage/*
 ui/libpeerconnection.log
 ui/npm-debug.log
 ui/testem.log
+
+# IAM
+vault-tester.json

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,12 @@ test: fmtcheck generate
 		echo "ERROR: Set TEST to a specific package"; \
 		exit 1; \
 	fi
-	VAULT_ACC=1 go test -tags='$(BUILD_TAGS)' $(TEST) -v $(TESTARGS) -parallel=40 -timeout 45m
+	@VAULT_ACC=1 go test -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -parallel=20 -timeout=60s
 
 # generate runs `go generate` to build the dynamically generated
 # source files.
 generate:
-	go generate $(go list ./... | grep -v /vendor/)
+	@go generate $(go list ./... | grep -v /vendor/)
 
 # bootstrap the build by downloading additional tools
 bootstrap:

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -2,9 +2,12 @@ package gcpauth
 
 import (
 	"context"
-	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache"
 	"github.com/hashicorp/vault/helper/useragent"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
@@ -13,16 +16,20 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/iam/v1"
-	"net/http"
 )
 
-const defaultCloudScope = "https://www.googleapis.com/auth/cloud-platform"
+var (
+	// cacheTime is the duration for which to cache clients and credentials. This
+	// must be less than 60 minutes.
+	cacheTime = 30 * time.Minute
+)
 
 type GcpAuthBackend struct {
 	*framework.Backend
 
-	// OAuth scopes for generating HTTP and GCP service clients.
-	oauthScopes []string
+	// cache is the internal client/object cache. Callers should never access the
+	// cache directly.
+	cache *cache.Cache
 }
 
 // Factory returns a new backend as logical.Backend.
@@ -36,7 +43,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 func Backend() *GcpAuthBackend {
 	b := &GcpAuthBackend{
-		oauthScopes: []string{defaultCloudScope},
+		cache: cache.New(),
 	}
 
 	b.Backend = &framework.Backend{
@@ -58,94 +65,167 @@ func Backend() *GcpAuthBackend {
 			},
 			pathsRole(b),
 		),
+
+		Invalidate: b.invalidate,
 	}
 	return b
 }
 
-func (b *GcpAuthBackend) httpClient(ctx context.Context, s logical.Storage) (*http.Client, error) {
-	config, err := b.config(ctx, s)
+// IAMClient returns a new IAM client. The client is cached.
+func (b *GcpAuthBackend) IAMClient(s logical.Storage) (*iam.Service, error) {
+	httpClient, err := b.httpClient(s)
 	if err != nil {
-		return nil, errwrap.Wrapf(
-			"could not check to see if GCP credentials were configured, error"+
-				"reading config: {{err}}", err)
+		return nil, errwrap.Wrapf("failed to create IAM HTTP client: {{err}}", err)
 	}
 
-	credsBytes, err := config.formatAndMarshalCredentials()
+	client, err := b.cache.Fetch("iam", cacheTime, func() (interface{}, error) {
+		client, err := iam.New(httpClient)
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to create IAM client: {{err}}", err)
+		}
+		client.UserAgent = useragent.String()
+
+		return client, nil
+	})
 	if err != nil {
-		return nil, errwrap.Wrapf(
-			"unable to marshal given GCP credential JSON: {{err}}", err)
+		return nil, err
 	}
 
-	var creds *google.Credentials
-	if config != nil && config.Credentials != nil {
-		creds, err = google.CredentialsFromJSON(ctx, credsBytes, b.oauthScopes...)
-		if err != nil {
-			return nil, errwrap.Wrapf("failed to parse credentials: {{err}}", err)
-		}
-	} else {
-		creds, err = google.FindDefaultCredentials(ctx, b.oauthScopes...)
-		if err != nil {
-			return nil, errwrap.Wrapf(
-				"credentials were not configured and Vault could not find "+
-					"Application Default Credentials (ADC). Either set ADC or "+
-					"configure this auth backend at auth/$MOUNT/config "+
-					"(default auth/gcp/config). Error: {{err}}", err)
-		}
-	}
-
-	cleanCtx := context.WithValue(ctx, oauth2.HTTPClient, cleanhttp.DefaultClient())
-	client := oauth2.NewClient(cleanCtx, creds.TokenSource)
-	return client, nil
+	return client.(*iam.Service), nil
 }
 
-func (b *GcpAuthBackend) newGcpClients(ctx context.Context, s logical.Storage) (*clientHandles, error) {
-	httpC, err := b.httpClient(ctx, s)
+// ComputeClient returns a new Compute client. The client is cached.
+func (b *GcpAuthBackend) ComputeClient(s logical.Storage) (*compute.Service, error) {
+	httpClient, err := b.httpClient(s)
 	if err != nil {
-		return nil, errwrap.Wrapf("could not obtain HTTP client: {{err}}", err)
+		return nil, errwrap.Wrapf("failed to create Compute HTTP client: {{err}}", err)
 	}
 
-	iamClient, err := iam.New(httpC)
-	if err != nil {
-		return nil, fmt.Errorf(clientErrorTemplate, "IAM", err)
-	}
-	iamClient.UserAgent = useragent.String()
+	client, err := b.cache.Fetch("compute", cacheTime, func() (interface{}, error) {
+		client, err := compute.New(httpClient)
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to create Compute client: {{err}}", err)
+		}
+		client.UserAgent = useragent.String()
 
-	gceClient, err := compute.New(httpC)
+		return client, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf(clientErrorTemplate, "Compute", err)
+		return nil, err
 	}
-	iamClient.UserAgent = useragent.String()
 
-	crmClient, err := cloudresourcemanager.New(httpC)
-	if err != nil {
-		return nil, fmt.Errorf(clientErrorTemplate, "Cloud Resource Manager", err)
-	}
-	crmClient.UserAgent = useragent.String()
-
-	return &clientHandles{
-		iam:             iamClient,
-		gce:             gceClient,
-		resourceManager: crmClient,
-	}, nil
+	return client.(*compute.Service), nil
 }
 
-type clientHandles struct {
-	iam             *iam.Service
-	gce             *compute.Service
-	resourceManager *cloudresourcemanager.Service
+// CRMClient returns a new Cloud Resource Manager client. The client is cached.
+func (b *GcpAuthBackend) CRMClient(s logical.Storage) (*cloudresourcemanager.Service, error) {
+	httpClient, err := b.httpClient(s)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to create Cloud Resource Manager HTTP client: {{err}}", err)
+	}
+
+	client, err := b.cache.Fetch("crm", cacheTime, func() (interface{}, error) {
+		client, err := cloudresourcemanager.New(httpClient)
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to create Cloud Resource Manager client: {{err}}", err)
+		}
+		client.UserAgent = useragent.String()
+
+		return client, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.(*cloudresourcemanager.Service), nil
+}
+
+// httpClient returns a new http.Client that is authenticated using the provided
+// credentials. The underlying httpClient is cached among all clients.
+func (b *GcpAuthBackend) httpClient(s logical.Storage) (*http.Client, error) {
+	creds, err := b.credentials(s)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to create oauth2 http client: {{err}}", err)
+	}
+
+	client, err := b.cache.Fetch("HTTPClient", cacheTime, func() (interface{}, error) {
+		b.Logger().Debug("creating oauth2 http client")
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, cleanhttp.DefaultClient())
+		return oauth2.NewClient(ctx, creds.TokenSource), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.(*http.Client), nil
+}
+
+// credentials returns the credentials which were specified in the
+// configuration. If no credentials were given during configuration, this uses
+// default application credentials. If no default application credentials are
+// found, this function returns an error. The credentials are cached in-memory
+// for performance.
+func (b *GcpAuthBackend) credentials(s logical.Storage) (*google.Credentials, error) {
+	creds, err := b.cache.Fetch("credentials", cacheTime, func() (interface{}, error) {
+		b.Logger().Debug("loading credentials")
+
+		ctx := context.Background()
+
+		config, err := b.config(ctx, s)
+		if err != nil {
+			return nil, err
+		}
+
+		// Get creds from the config
+		credBytes, err := config.formatAndMarshalCredentials()
+		if err != nil {
+			return nil, errwrap.Wrapf("failed to marshal credential JSON: {{err}}", err)
+		}
+
+		// If credentials were provided, use those. Otherwise fall back to the
+		// default application credentials.
+		var creds *google.Credentials
+		if len(credBytes) > 0 {
+			creds, err = google.CredentialsFromJSON(ctx, credBytes, iam.CloudPlatformScope)
+			if err != nil {
+				return nil, errwrap.Wrapf("failed to parse credentials: {{err}}", err)
+			}
+		} else {
+			creds, err = google.FindDefaultCredentials(ctx, iam.CloudPlatformScope)
+			if err != nil {
+				return nil, errwrap.Wrapf("failed to get default credentials: {{err}}", err)
+			}
+		}
+
+		return creds, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return creds.(*google.Credentials), nil
+}
+
+// ClearCaches deletes all cached clients and credentials.
+func (b *GcpAuthBackend) ClearCaches() {
+	b.cache.Clear()
+}
+
+// invalidate resets the plugin. This is called when a key is updated via
+// replication.
+func (b *GcpAuthBackend) invalidate(ctx context.Context, key string) {
+	switch key {
+	case "config":
+		b.ClearCaches()
+	}
 }
 
 const backendHelp = `
-The GCP backend plugin allows authentication for Google Cloud Platform entities.
-Currently, it supports authentication for:
+The GCP auth method allows machines to authenticate Google Cloud Platform
+entities. It supports two modes of authentication:
 
-* IAM Service Accounts:
-	IAM service accounts provide a signed JSON Web Token (JWT), signed by
-	calling GCP APIs directly or via the Vault CL helper.
+- IAM service accounts: provides a signed JSON Web Token for a given
+  service account key
 
-* GCE VM Instances:
-	GCE provide a signed instance metadata JSON Web Token (JWT), obtained from the
-	GCE instance metadata server  (http://metadata.google.internal/computeMetadata/v1/instance).
-	Using the /service-accounts/<service-account-name>/identity	endpoint, the instance
-	can obtain this JWT and pass it to Vault on login.
+- GCE VM metadata: provides a signed JSON Web Token using instance metadata
+  obtained from the GCE instance metadata server
 `

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -3,55 +3,89 @@ package gcpauth
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/go-gcp-common/gcputil"
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/helper/logging"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/logical"
 )
 
-func getTestBackend(t *testing.T) (logical.Backend, logical.Storage) {
-	testAccPreCheck(t)
+const (
+	googleCredentialsEnv = "GOOGLE_CREDENTIALS"
+)
 
-	defaultLeaseTTLVal := time.Hour * 12
-	maxLeaseTTLVal := time.Hour * 24
-	b := Backend()
-
-	config := &logical.BackendConfig{
-		Logger: logging.NewVaultLogger(log.Trace),
-		System: &logical.StaticSystemView{
-			DefaultLeaseTTLVal: defaultLeaseTTLVal,
-			MaxLeaseTTLVal:     maxLeaseTTLVal,
-		},
-		StorageView: &logical.InmemStorage{},
-	}
-
-	err := b.Setup(context.Background(), config)
-	if err != nil {
-		t.Fatalf("unable to create backend: %v", err)
-	}
-
-	return b, config.StorageView
-}
-
-func testAccPreCheck(t *testing.T) {
-	getTestCredentials(t)
-}
-
-func getTestCredentials(tb testing.TB) *gcputil.GcpCredentials {
+func testBackend(tb testing.TB) (*GcpAuthBackend, logical.Storage) {
 	tb.Helper()
 
-	credentialsJSON := os.Getenv(googleCredentialsEnv)
-	if credentialsJSON == "" {
+	config := logical.TestBackendConfig()
+	config.StorageView = new(logical.InmemStorage)
+	config.Logger = hclog.NewNullLogger()
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return b.(*GcpAuthBackend), config.StorageView
+}
+
+// testBackendWithCreds returns a new backend pre-populated with the
+// credentials from the environment in the configuration.
+func testBackendWithCreds(tb testing.TB) (*GcpAuthBackend, logical.Storage, *gcputil.GcpCredentials) {
+	tb.Helper()
+
+	creds := testCredentials(tb)
+
+	b, storage := testBackend(tb)
+	ctx := context.Background()
+
+	entry, err := logical.StorageEntryJSON("config", &gcpConfig{
+		Credentials: creds,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if err := storage.Put(ctx, entry); err != nil {
+		tb.Fatal(err)
+	}
+
+	return b, storage, creds
+}
+
+func testCredentials(tb testing.TB) *gcputil.GcpCredentials {
+	tb.Helper()
+
+	creds := os.Getenv(googleCredentialsEnv)
+	if creds == "" {
 		tb.Fatalf("%s must be set to JSON string of valid Google credentials file", googleCredentialsEnv)
 	}
 
-	credentials, err := gcputil.Credentials(credentialsJSON)
+	credentials, err := gcputil.Credentials(creds)
 	if err != nil {
 		tb.Fatalf("valid Google credentials JSON could not be read from %s env variable: %v", googleCredentialsEnv, err)
 	}
 
 	return credentials
+}
+
+// testFieldValidation verifies the given path has field validation.
+func testFieldValidation(tb testing.TB, op logical.Operation, pth string) {
+	tb.Helper()
+
+	b, storage := testBackend(tb)
+	ctx := context.Background()
+	_, err := b.HandleRequest(ctx, &logical.Request{
+		Storage:   storage,
+		Operation: op,
+		Path:      pth,
+		Data: map[string]interface{}{
+			"literally-never-a-key": true,
+		},
+	})
+	if err == nil {
+		tb.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unknown field") {
+		tb.Error(err)
+	}
 }

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -37,7 +37,7 @@ func (c *Cache) Fetch(name string, t time.Duration, f Func) (interface{}, error)
 	// valid.
 	c.lock.RLock()
 	e, ok := c.data[name]
-	if ok && e.result != nil && time.Now().UTC().Sub(e.created) < e.lifetime {
+	if ok && e.result != nil && time.Now().Sub(e.created) < e.lifetime {
 		c.lock.RUnlock()
 		return e.result, nil
 	}
@@ -50,7 +50,7 @@ func (c *Cache) Fetch(name string, t time.Duration, f Func) (interface{}, error)
 	// another concurrent invocation sized the lock between our RLock and Lock,
 	// thus we have to check again.
 	e, ok = c.data[name]
-	if ok && e.result != nil && time.Now().UTC().Sub(e.created) < e.lifetime {
+	if ok && e.result != nil && time.Now().Sub(e.created) < e.lifetime {
 		c.lock.Unlock()
 		return e.result, nil
 	}
@@ -63,7 +63,7 @@ func (c *Cache) Fetch(name string, t time.Duration, f Func) (interface{}, error)
 
 	c.data[name] = &cacheEntry{
 		result:   result,
-		created:  time.Now().UTC(),
+		created:  time.Now(),
 		lifetime: t,
 	}
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -1,0 +1,78 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+// New creates a cacher.
+func New() *Cache {
+	return &Cache{
+		data: map[string]*cacheEntry{},
+	}
+}
+
+// Func is the signature for a cache function.
+type Func func() (interface{}, error)
+
+// Cache is the internal cache implementation.
+type Cache struct {
+	lock sync.RWMutex
+	data map[string]*cacheEntry
+}
+
+// cacheEntry represents an item in the cache with an expiration and lifetime.
+type cacheEntry struct {
+	result   interface{}
+	created  time.Time
+	lifetime time.Duration
+}
+
+// Fetch retrieves an item from the cache. If the item exists in the cache and
+// is within its lifetime, it is returned. If the item does not exist, or if the
+// item exists but has exceeded its lifetime, the function f is invoked and the
+// result is updated in the cache.
+func (c *Cache) Fetch(name string, t time.Duration, f Func) (interface{}, error) {
+	// Attempt to read from the cache, returning the cached value if it's still
+	// valid.
+	c.lock.RLock()
+	e, ok := c.data[name]
+	if ok && e.result != nil && time.Now().UTC().Sub(e.created) < e.lifetime {
+		c.lock.RUnlock()
+		return e.result, nil
+	}
+	c.lock.RUnlock()
+
+	// Either no cached value exists, or the cached item has exceeded its lifetime.
+	c.lock.Lock()
+
+	result, err := f()
+	if err != nil {
+		c.lock.Unlock()
+		return nil, err
+	}
+
+	c.data[name] = &cacheEntry{
+		result:   result,
+		created:  time.Now().UTC(),
+		lifetime: t,
+	}
+
+	c.lock.Unlock()
+
+	return result, nil
+}
+
+// Expire removes the given item from the cache, if it exists.
+func (c *Cache) Expire(name string) {
+	c.lock.Lock()
+	delete(c.data, name)
+	c.lock.Unlock()
+}
+
+// Clear empties the cache for all values.
+func (c *Cache) Clear() {
+	c.lock.Lock()
+	c.data = map[string]*cacheEntry{}
+	c.lock.Unlock()
+}

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -5,94 +5,331 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/vault/helper/jsonutil"
+	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
 )
 
-func TestConfig(t *testing.T) {
+func TestBackend_PathConfigRead(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
-
-	testConfigRead(t, b, reqStorage, nil)
-
-	creds := map[string]interface{}{
-		"client_email":   "testUser@google.com",
-		"client_id":      "user123",
-		"private_key_id": "privateKey123",
-		"private_key":    "iAmAPrivateKey",
-		"project_id":     "project123",
-	}
-
-	credJson, err := jsonutil.EncodeJSON(creds)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testConfigUpdate(t, b, reqStorage, map[string]interface{}{
-		"credentials": credJson,
+	t.Run("field_validation", func(t *testing.T) {
+		t.Parallel()
+		testFieldValidation(t, logical.ReadOperation, "config")
 	})
 
-	expected := map[string]interface{}{
-		"client_email":   creds["client_email"],
-		"client_id":      creds["client_id"],
-		"private_key_id": creds["private_key_id"],
-		"project_id":     creds["project_id"],
-	}
+	t.Run("not_exist", func(t *testing.T) {
+		t.Parallel()
 
-	testConfigRead(t, b, reqStorage, expected)
-	creds["project_id"] = "newProjectId123"
-	credJson, err = jsonutil.EncodeJSON(creds)
-	if err != nil {
-		t.Fatal(err)
-	}
-	testConfigUpdate(t, b, reqStorage, map[string]interface{}{
-		"credentials": credJson,
+		b, storage := testBackend(t)
+		ctx := context.Background()
+		resp, err := b.HandleRequest(ctx, &logical.Request{
+			Storage:   storage,
+			Operation: logical.ReadOperation,
+			Path:      "config",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp != nil {
+			t.Errorf("expected response data to be empty, got %v", resp.Data)
+		}
 	})
 
-	expected["project_id"] = "newProjectId123"
-	testConfigRead(t, b, reqStorage, expected)
+	t.Run("exist", func(t *testing.T) {
+		t.Parallel()
+
+		b, storage := testBackend(t)
+		ctx := context.Background()
+
+		entry, err := logical.StorageEntryJSON("config", &gcpConfig{
+			Credentials: &gcputil.GcpCredentials{
+				ClientEmail:  "user@test.com",
+				ClientId:     "user",
+				PrivateKeyId: "key_id",
+				PrivateKey:   "key",
+				ProjectId:    "project",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := storage.Put(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := b.HandleRequest(ctx, &logical.Request{
+			Storage:   storage,
+			Operation: logical.ReadOperation,
+			Path:      "config",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if v, exp := resp.Data["client_email"].(string), "user@test.com"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := resp.Data["client_id"].(string), "user"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := resp.Data["private_key_id"].(string), "key_id"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := resp.Data["project_id"].(string), "project"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, ok := resp.Data["private_key"]; ok {
+			t.Errorf("expected %q to be missing", v)
+		}
+	})
 }
 
-func testConfigUpdate(tb testing.TB, b logical.Backend, s logical.Storage, d map[string]interface{}) {
-	tb.Helper()
+func TestBackend_PathConfigWrite(t *testing.T) {
+	t.Parallel()
 
-	resp, err := b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config",
-		Data:      d,
-		Storage:   s,
+	t.Run("field_validation", func(t *testing.T) {
+		t.Parallel()
+		testFieldValidation(t, logical.UpdateOperation, "config")
 	})
-	if err != nil {
-		tb.Fatal(err)
-	}
-	if resp != nil && resp.IsError() {
-		tb.Fatal(resp.Error())
-	}
+
+	t.Run("not_exist", func(t *testing.T) {
+		t.Parallel()
+
+		b, storage := testBackend(t)
+		ctx := context.Background()
+		if _, err := b.HandleRequest(ctx, &logical.Request{
+			Storage:   storage,
+			Operation: logical.UpdateOperation,
+			Path:      "config",
+			Data: map[string]interface{}{
+				"credentials": `{
+				  "project_id": "project_id",
+				  "private_key_id": "key_id",
+				  "private_key": "key",
+				  "client_email": "user@test.com",
+				  "client_id": "client_id"
+				}`,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := b.config(ctx, storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		creds := config.Credentials
+		if creds == nil {
+			t.Fatal("expected credentials to exist")
+		}
+
+		if v, exp := creds.ClientEmail, "user@test.com"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.ClientId, "client_id"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.PrivateKeyId, "key_id"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.PrivateKey, "key"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.ProjectId, "project_id"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+	})
+
+	t.Run("exist", func(t *testing.T) {
+		t.Parallel()
+
+		b, storage := testBackend(t)
+		ctx := context.Background()
+
+		entry, err := logical.StorageEntryJSON("config", &gcpConfig{
+			Credentials: &gcputil.GcpCredentials{
+				ClientEmail:  "user@test.com",
+				ClientId:     "user",
+				PrivateKeyId: "key_id",
+				PrivateKey:   "key",
+				ProjectId:    "project",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := storage.Put(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := b.HandleRequest(ctx, &logical.Request{
+			Storage:   storage,
+			Operation: logical.UpdateOperation,
+			Path:      "config",
+			Data: map[string]interface{}{
+				"credentials": `{
+				  "project_id": "2project_id",
+				  "private_key_id": "2key_id",
+				  "private_key": "2key",
+				  "client_email": "2user@test.com",
+				  "client_id": "2client_id"
+				}`,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		config, err := b.config(ctx, storage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		creds := config.Credentials
+		if creds == nil {
+			t.Fatal("expected credentials to exist")
+		}
+
+		if v, exp := creds.ClientEmail, "2user@test.com"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.ClientId, "2client_id"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.PrivateKeyId, "2key_id"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.PrivateKey, "2key"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+
+		if v, exp := creds.ProjectId, "2project_id"; v != exp {
+			t.Errorf("expected %q to be %q", v, exp)
+		}
+	})
 }
 
-func testConfigRead(tb testing.TB, b logical.Backend, s logical.Storage, expected map[string]interface{}) {
-	tb.Helper()
+func TestConfig_Update(t *testing.T) {
+	t.Parallel()
 
-	resp, err := b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "config",
-		Storage:   s,
-	})
-
-	if err != nil {
-		tb.Fatal(err)
+	cases := []struct {
+		name    string
+		new     *gcpConfig
+		d       *framework.FieldData
+		r       *gcpConfig
+		changed bool
+		err     bool
+	}{
+		{
+			"empty",
+			&gcpConfig{},
+			nil,
+			&gcpConfig{},
+			false,
+			false,
+		},
+		{
+			"keeps_existing",
+			&gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			nil,
+			&gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			false,
+			false,
+		},
+		{
+			"overwrites_changes",
+			&gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			&framework.FieldData{
+				Raw: map[string]interface{}{
+					"credentials": `{
+						"client_id": "bar",
+						"private_key_id": "aaa"
+					}`,
+				},
+			},
+			&gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId:     "bar",
+					PrivateKeyId: "aaa",
+				},
+			},
+			true,
+			false,
+		},
+		{
+			"overwrites_and_new",
+			&gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			&framework.FieldData{
+				Raw: map[string]interface{}{
+					"credentials": `{
+						"client_id": "foo",
+						"private_key_id": "aaa"
+					}`,
+				},
+			},
+			&gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId:     "foo",
+					PrivateKeyId: "aaa",
+				},
+			},
+			true,
+			false,
+		},
 	}
 
-	if resp == nil && expected == nil {
-		return
-	}
+	for _, tc := range cases {
+		tc := tc
 
-	if resp.IsError() {
-		tb.Fatal(resp.Error())
-	}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	if !reflect.DeepEqual(resp.Data, expected) {
-		tb.Fatalf("config mismatch, expected %v but actually %v", expected, resp.Data)
+			if tc.d != nil {
+				var b GcpAuthBackend
+				tc.d.Schema = pathConfig(&b).Fields
+			}
+
+			changed, err := tc.new.Update(tc.d)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if changed != tc.changed {
+				t.Errorf("expected %t to be %t", changed, tc.changed)
+			}
+
+			if v, exp := tc.new.Credentials, tc.r.Credentials; !reflect.DeepEqual(v, exp) {
+				t.Errorf("expected %q to be %q", v, exp)
+			}
+		})
 	}
 }

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -525,12 +525,9 @@ func (b *GcpAuthBackend) groupAliases(crmClient *cloudresourcemanager.Service, c
 		return nil, err
 	}
 
-	aliases := make([]*logical.Alias, len(ancestry.Ancestor)+1)
-	aliases[0] = &logical.Alias{
-		Name: fmt.Sprintf("project-%s", projectId),
-	}
+	aliases := make([]*logical.Alias, len(ancestry.Ancestor))
 	for i, parent := range ancestry.Ancestor {
-		aliases[i+1] = &logical.Alias{
+		aliases[i] = &logical.Alias{
 			Name: fmt.Sprintf("%s-%s", parent.ResourceId.Type, parent.ResourceId.Id),
 		}
 	}

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -23,8 +23,6 @@ import (
 
 const (
 	expectedJwtAudTemplate string = "vault/%s"
-
-	clientErrorTemplate string = "backend not configured properly, could not create %s client: %v"
 )
 
 func pathLogin(b *GcpAuthBackend) *framework.Path {
@@ -200,16 +198,17 @@ func (b *GcpAuthBackend) getSigningKey(ctx context.Context, token *jwt.JSONWebTo
 
 	switch role.RoleType {
 	case iamRoleType:
-		clients, err := b.newGcpClients(ctx, s)
+		iamClient, err := b.IAMClient(s)
 		if err != nil {
 			return nil, err
 		}
+
 		serviceAccountId, err := parseServiceAccountFromIAMJWT(rawToken)
 		if err != nil {
 			return nil, err
 		}
 
-		accountKey, err := gcputil.ServiceAccountKey(clients.iam, &gcputil.ServiceAccountKeyId{
+		accountKey, err := gcputil.ServiceAccountKey(iamClient, &gcputil.ServiceAccountKeyId{
 			Project:   "-",
 			EmailOrId: serviceAccountId,
 			Key:       keyId,
@@ -279,7 +278,7 @@ func validateBaseJWTClaims(c *jwt.Claims, roleName string) error {
 // ---- IAM login domain ----
 // pathIamLogin attempts a login operation using the parsed login info.
 func (b *GcpAuthBackend) pathIamLogin(ctx context.Context, req *logical.Request, loginInfo *gcpLoginInfo) (*logical.Response, error) {
-	clients, err := b.newGcpClients(ctx, req.Storage)
+	iamClient, err := b.IAMClient(req.Storage)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +299,7 @@ func (b *GcpAuthBackend) pathIamLogin(ctx context.Context, req *logical.Request,
 		Project:   "-",
 		EmailOrId: loginInfo.EmailOrId,
 	}
-	serviceAccount, err := gcputil.ServiceAccount(clients.iam, accountId)
+	serviceAccount, err := gcputil.ServiceAccount(iamClient, accountId)
 	if err != nil {
 		return nil, err
 	}
@@ -340,12 +339,12 @@ func (b *GcpAuthBackend) pathIamLogin(ctx context.Context, req *logical.Request,
 		},
 	}
 	if role.AddGroupAliases {
-		clients, err := b.newGcpClients(ctx, req.Storage)
+		crmClient, err := b.CRMClient(req.Storage)
 		if err != nil {
 			return nil, err
 		}
 
-		aliases, err := b.groupAliases(clients.resourceManager, ctx, serviceAccount.ProjectId)
+		aliases, err := b.groupAliases(crmClient, ctx, serviceAccount.ProjectId)
 		if err != nil {
 			return nil, err
 		}
@@ -358,7 +357,7 @@ func (b *GcpAuthBackend) pathIamLogin(ctx context.Context, req *logical.Request,
 // pathIamRenew returns an error if the service account referenced in the auth token metadata cannot renew the
 // auth token for the given role.
 func (b *GcpAuthBackend) pathIamRenew(ctx context.Context, req *logical.Request, roleName string, role *gcpRole) error {
-	clients, err := b.newGcpClients(ctx, req.Storage)
+	iamClient, err := b.IAMClient(req.Storage)
 	if err != nil {
 		return err
 	}
@@ -374,7 +373,7 @@ func (b *GcpAuthBackend) pathIamRenew(ctx context.Context, req *logical.Request,
 		project = "-"
 	}
 
-	serviceAccount, err := gcputil.ServiceAccount(clients.iam, &gcputil.ServiceAccountId{
+	serviceAccount, err := gcputil.ServiceAccount(iamClient, &gcputil.ServiceAccountId{
 		Project:   project,
 		EmailOrId: serviceAccountId,
 	})
@@ -430,12 +429,12 @@ func (b *GcpAuthBackend) pathGceLogin(ctx context.Context, req *logical.Request,
 	}
 
 	// Verify instance exists.
-	clients, err := b.newGcpClients(ctx, req.Storage)
+	computeClient, err := b.ComputeClient(req.Storage)
 	if err != nil {
 		return nil, err
 	}
 
-	instance, err := metadata.GetVerifiedInstance(clients.gce)
+	instance, err := metadata.GetVerifiedInstance(computeClient)
 	if err != nil {
 		return logical.ErrorResponse(fmt.Sprintf(
 			"error when attempting to find instance (project %s, zone: %s, instance: %s) :%v",
@@ -456,7 +455,12 @@ func (b *GcpAuthBackend) pathGceLogin(ctx context.Context, req *logical.Request,
 		}, nil
 	}
 
-	serviceAccount, err := gcputil.ServiceAccount(clients.iam, &gcputil.ServiceAccountId{
+	iamClient, err := b.IAMClient(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceAccount, err := gcputil.ServiceAccount(iamClient, &gcputil.ServiceAccountId{
 		Project:   "-",
 		EmailOrId: loginInfo.EmailOrId,
 	})
@@ -485,7 +489,12 @@ func (b *GcpAuthBackend) pathGceLogin(ctx context.Context, req *logical.Request,
 	}
 
 	if role.AddGroupAliases {
-		aliases, err := b.groupAliases(clients.resourceManager, ctx, metadata.ProjectId)
+		crmClient, err := b.CRMClient(req.Storage)
+		if err != nil {
+			return nil, err
+		}
+
+		aliases, err := b.groupAliases(crmClient, ctx, metadata.ProjectId)
 		if err != nil {
 			return nil, err
 		}
@@ -551,14 +560,9 @@ func authMetadata(loginInfo *gcpLoginInfo, serviceAccount *iam.ServiceAccount) m
 // pathGceRenew returns an error if the instance referenced in the auth token metadata cannot renew the
 // auth token for the given role.
 func (b *GcpAuthBackend) pathGceRenew(ctx context.Context, req *logical.Request, roleName string, role *gcpRole) error {
-	httpC, err := b.httpClient(ctx, req.Storage)
+	computeClient, err := b.ComputeClient(req.Storage)
 	if err != nil {
 		return err
-	}
-
-	gceClient, err := compute.New(httpC)
-	if err != nil {
-		return fmt.Errorf(clientErrorTemplate, "GCE", err)
 	}
 
 	meta, err := getInstanceMetadataFromAuth(req.Auth.Metadata)
@@ -566,7 +570,7 @@ func (b *GcpAuthBackend) pathGceRenew(ctx context.Context, req *logical.Request,
 		return fmt.Errorf("invalid auth metadata: %v", err)
 	}
 
-	instance, err := meta.GetVerifiedInstance(gceClient)
+	instance, err := meta.GetVerifiedInstance(computeClient)
 	if err != nil {
 		return err
 	}
@@ -632,24 +636,19 @@ func getInstanceMetadataFromAuth(authMetadata map[string]string) (*gcputil.GCEId
 // authorizeGCEInstance returns an error if the given GCE instance is not
 // authorized for the role.
 func (b *GcpAuthBackend) authorizeGCEInstance(ctx context.Context, project string, instance *compute.Instance, s logical.Storage, role *gcpRole, serviceAccountId string) error {
-	httpC, err := b.httpClient(ctx, s)
+	iamClient, err := b.IAMClient(s)
 	if err != nil {
 		return err
 	}
 
-	iamClient, err := iam.New(httpC)
+	computeClient, err := b.ComputeClient(s)
 	if err != nil {
-		return fmt.Errorf(clientErrorTemplate, "IAM", err)
-	}
-
-	gceClient, err := compute.New(httpC)
-	if err != nil {
-		return fmt.Errorf(clientErrorTemplate, "GCE", err)
+		return nil
 	}
 
 	return AuthorizeGCE(ctx, &AuthorizeGCEInput{
 		client: &gcpClient{
-			computeSvc: gceClient,
+			computeSvc: computeClient,
 			iamSvc:     iamClient,
 		},
 		serviceAccount:   serviceAccountId,

--- a/plugin/path_role.go
+++ b/plugin/path_role.go
@@ -595,6 +595,9 @@ type gcpRole struct {
 	// Service accounts allowed to login under this role.
 	BoundServiceAccounts []string `json:"bound_service_accounts,omitempty"`
 
+	// AddGroupAliases adds Vault group aliases to the response.
+	AddGroupAliases bool `json:"add_group_aliases,omitempty"`
+
 	// --| IAM-only attributes |--
 	// MaxJwtExp is the duration from time of authentication that a JWT used to authenticate to role must expire within.
 	// TODO(emilymye): Allow this to be updated for GCE roles once 'exp' parameter has been allowed for GCE metadata.
@@ -616,8 +619,6 @@ type gcpRole struct {
 
 	// BoundLabels that instances must currently have set in order to login under this role.
 	BoundLabels map[string]string `json:"bound_labels,omitempty"`
-
-	AddGroupAliases bool `json:"add_group_aliases,omitempty"`
 
 	// Deprecated fields
 	// TODO: Remove in 0.5.0+

--- a/plugin/path_role_test.go
+++ b/plugin/path_role_test.go
@@ -39,7 +39,7 @@ var expectedDefaults = map[string]interface{}{
 func TestRoleUpdateIam(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	serviceAccounts := []string{"dev1@project-123456.iam.gserviceaccounts.com", "aserviceaccountid"}
 
@@ -86,7 +86,7 @@ func TestRoleUpdateIam(t *testing.T) {
 func TestRoleIam_Wildcard(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	serviceAccounts := []string{"*", "dev1@project-123456.iam.gserviceaccounts.com", "aserviceaccountid"}
 
@@ -116,7 +116,7 @@ func TestRoleIam_Wildcard(t *testing.T) {
 func TestRoleIam_EditServiceAccounts(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	roleName, projectId := testRoleAndProject(t)
 	projects := []string{projectId, "another-project"}
@@ -170,7 +170,7 @@ func TestRoleIam_EditServiceAccounts(t *testing.T) {
 func TestRoleIam_MissingRequiredArgs(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	roleName, _ := testRoleAndProject(t)
 
@@ -190,7 +190,7 @@ func TestRoleIam_MissingRequiredArgs(t *testing.T) {
 func TestRoleIam_HasGceArgs(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	roleName, projectId := testRoleAndProject(t)
 
@@ -207,7 +207,7 @@ func TestRoleIam_HasGceArgs(t *testing.T) {
 func TestRoleGce(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	roleName, projectId := testRoleAndProject(t)
 
@@ -259,7 +259,7 @@ func TestRoleGce(t *testing.T) {
 func TestRoleGce_EditLabels(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	roleName, projectId := testRoleAndProject(t)
 
@@ -315,7 +315,7 @@ func TestRoleGce_DeprecatedFields(t *testing.T) {
 	t.Run("deprecated_fields_upgraded", func(t *testing.T) {
 		t.Parallel()
 
-		b, storage := getTestBackend(t)
+		b, storage := testBackend(t)
 
 		roleName, projectId := testRoleAndProject(t)
 
@@ -343,7 +343,7 @@ func TestRoleGce_DeprecatedFields(t *testing.T) {
 	t.Run("existing_storage_upgraded", func(t *testing.T) {
 		t.Parallel()
 
-		b, storage := getTestBackend(t)
+		b, storage := testBackend(t)
 
 		roleName, projectId := testRoleAndProject(t)
 
@@ -402,7 +402,7 @@ func TestRoleGce_DeprecatedFields(t *testing.T) {
 func TestRole_MissingRequiredArgs(t *testing.T) {
 	t.Parallel()
 
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	roleName, projectId := testRoleAndProject(t)
 
@@ -421,7 +421,7 @@ func TestRole_MissingRequiredArgs(t *testing.T) {
 }
 
 func TestRole_InvalidRoleType(t *testing.T) {
-	b, reqStorage := getTestBackend(t)
+	b, reqStorage := testBackend(t)
 
 	roleName, projectId := testRoleAndProject(t)
 


### PR DESCRIPTION
Our current implementation creates 3 new clients on each login request. For a large set of concurrent requests, this can exhaust FDs and dramatically slow down performance.

This PR implements client caching to cache each client instantiation for 30min (half of the 60min jwt expiration time). In local testing, this resulted in a 612x speedup when authenticating via IAM at 300 req/min for 5 minutes.