### PR TITLE
Remove equivalent policy check for token renewals

### DIFF
--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
-	"github.com/hashicorp/vault/sdk/helper/policyutil"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/logical"
 	"google.golang.org/api/cloudresourcemanager/v1"
@@ -99,8 +98,6 @@ func (b *GcpAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 		return nil, err
 	} else if role == nil {
 		return logical.ErrorResponse("role '%s' no longer exists"), nil
-	} else if !policyutil.EquivalentPolicies(role.Policies, req.Auth.Policies) {
-		return logical.ErrorResponse("policies on role '%s' have changed, cannot renew"), nil
 	}
 
 	switch role.RoleType {


### PR DESCRIPTION
Per the discussion on https://github.com/hashicorp/vault/issues/8449, this removes the equivalent policy check for renewals.