### PR TITLE
Fix token renewals when TokenPolicies have been configured

### DIFF
--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -98,9 +98,9 @@ func (b *GcpAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 	if err != nil {
 		return nil, err
 	} else if role == nil {
-		return logical.ErrorResponse("role '%s' no longer exists"), nil
-	} else if !policyutil.EquivalentPolicies(role.Policies, req.Auth.Policies) {
-		return logical.ErrorResponse("policies on role '%s' have changed, cannot renew"), nil
+		return logical.ErrorResponse(fmt.Sprintf("role '%s' no longer exists", roleName)), nil
+	} else if !policyutil.EquivalentPolicies(role.TokenPolicies, req.Auth.Policies) {
+		return logical.ErrorResponse(fmt.Sprintf("policies on role '%s' have changed, cannot renew", roleName)), nil
 	}
 
 	switch role.RoleType {

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -99,7 +99,7 @@ func (b *GcpAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Reques
 		return nil, err
 	} else if role == nil {
 		return logical.ErrorResponse(fmt.Sprintf("role '%s' no longer exists", roleName)), nil
-	} else if !policyutil.EquivalentPolicies(role.TokenPolicies, req.Auth.Policies) {
+	} else if !policyutil.EquivalentPolicies(role.TokenPolicies, req.Auth.TokenPolicies) {
 		return logical.ErrorResponse(fmt.Sprintf("policies on role '%s' have changed, cannot renew", roleName)), nil
 	}
 

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-gcp-common/gcputil"
+	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 	jose "gopkg.in/square/go-jose.v2"
@@ -270,6 +271,120 @@ func TestLogin_IAM(t *testing.T) {
 			t.Errorf("expected %q to contain %q", str, exp)
 		}
 	})
+}
+
+func Test_Renew(t *testing.T) {
+	b, storage, creds := testBackendWithCreds(t)
+
+	// Build the JWT token
+	iamClient, err := b.IAMClient(storage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := time.Now().Add(10 * time.Minute)
+	jwt, err := ServiceAccountLoginJwt(iamClient, exp, "vault/test", creds.ProjectId, creds.ClientEmail)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := &logical.Request{
+		Storage: storage,
+		Auth:    &logical.Auth{},
+	}
+
+	roleFieldSchema := map[string]*framework.FieldSchema{}
+	for k, v := range baseRoleFieldSchema() {
+		roleFieldSchema[k] = v
+	}
+	for k, v := range iamOnlyFieldSchema {
+		roleFieldSchema[k] = v
+	}
+
+	fd := &framework.FieldData{
+		Raw: map[string]interface{}{
+			"name":                   "test",
+			"type":                   "iam",
+			"max_jwt_exp":            30 * time.Minute,
+			"bound_service_accounts": creds.ClientEmail,
+			// Use the deprecated `policies` field
+			"policies": "foo,bar",
+		},
+		Schema: roleFieldSchema,
+	}
+
+	resp, err := b.pathRoleCreateUpdate(context.Background(), req, fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loginFd := &framework.FieldData{
+		Raw: map[string]interface{}{
+			"role": "test",
+			"jwt":  jwt.SignedJwt,
+		},
+		Schema: pathLogin(b).Fields,
+	}
+	resp, err = b.pathLogin(context.Background(), req, loginFd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.IsError() {
+		t.Fatalf("got error: %#v", *resp)
+	}
+	req.Auth.InternalData = resp.Auth.InternalData
+	req.Auth.Metadata = resp.Auth.Metadata
+	req.Auth.LeaseOptions = resp.Auth.LeaseOptions
+	req.Auth.Policies = resp.Auth.Policies
+	req.Auth.TokenPolicies = req.Auth.Policies
+	req.Auth.Period = resp.Auth.Period
+
+	// Normal renewal
+	renewFd := &framework.FieldData{}
+	resp, err = b.pathLoginRenew(context.Background(), req, renewFd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("got nil response from renew")
+	}
+	if resp.IsError() {
+		t.Fatalf("got error: %#v", *resp)
+	}
+
+	// Change the policies -- this should fail
+	fd.Raw["policies"] = "zip,zap"
+	resp, err = b.pathRoleCreateUpdate(context.Background(), req, fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = b.pathLoginRenew(context.Background(), req, renewFd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.IsError() {
+		t.Fatal("expected error")
+	}
+
+	// Put the policies back using the non-deprecated `token_policies` field, this should be okay
+	delete(fd.Raw, "policies")
+	fd.Raw["token_policies"] = "bar,foo"
+
+	resp, err = b.pathRoleCreateUpdate(context.Background(), req, fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = b.pathLoginRenew(context.Background(), req, renewFd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("got nil response from renew")
+	}
+	if resp.IsError() {
+		t.Fatalf("got error: %#v", *resp)
+	}
 }
 
 // testCreateExpiredJwtToken creates an expired IAM JWT token


### PR DESCRIPTION
When `TokenPolicies` have been configured for a GCP auth role the logic
compared role `Policies` to the request auth's policies. However, it
should have instead looked at the `TokenPolicies` which gets updated if
`TokenPolicies` were not configured and the `Policies` array is > 0 (see https://github.com/hashicorp/vault-plugin-auth-gcp/blob/135f3801429740545b5c9b73ed36614e07aa6b20/plugin/path_role.go#L538-L541).

This addresses https://github.com/hashicorp/vault-plugin-auth-gcp/issues/75

To work around the issue I instead configured the role with `policies` instead of `token_policies`.

Lastly, I've opened a separate Vault issue https://github.com/hashicorp/vault/issues/8449 to address making auth backends consistent in how they handle renewals. If this approach is acceptable, this PR can likely be closed.