### PR TITLE
Make identities less unique to improve performance

### DIFF
--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -453,7 +453,7 @@ func (b *GcpAuthBackend) pathGceLogin(ctx context.Context, req *logical.Request,
 		return &logical.Response{
 			Auth: &logical.Auth{
 				Alias: &logical.Alias{
-					Name: fmt.Sprintf("gce-%s", strconv.FormatUint(instance.Id, 10)),
+					Name: loginInfo.EmailOrId,
 				},
 			},
 		}, nil
@@ -475,7 +475,7 @@ func (b *GcpAuthBackend) pathGceLogin(ctx context.Context, req *logical.Request,
 	auth := &logical.Auth{
 		InternalData: map[string]interface{}{},
 		Alias: &logical.Alias{
-			Name: fmt.Sprintf("gce-%s", strconv.FormatUint(instance.Id, 10)),
+			Name: serviceAccount.UniqueId,
 		},
 		Metadata:    authMetadata(loginInfo, serviceAccount),
 		DisplayName: instance.Name,
@@ -546,9 +546,6 @@ func authMetadata(loginInfo *gcpLoginInfo, serviceAccount *iam.ServiceAccount) m
 		metadata["project_id"] = gceMetadata.ProjectId
 		metadata["project_number"] = strconv.FormatInt(gceMetadata.ProjectNumber, 10)
 		metadata["zone"] = gceMetadata.Zone
-		metadata["instance_id"] = gceMetadata.InstanceId
-		metadata["instance_name"] = gceMetadata.InstanceName
-		metadata["instance_creation_timestamp"] = strconv.FormatInt(gceMetadata.CreatedAt, 10)
 	}
 	return metadata
 }


### PR DESCRIPTION
Signed-off-by: Dustin Decker <dustindecker@protonmail.com>

# Overview
This change removes instance display names and metadata from GCP auth login responses. This increase performance at the expense of tracability.

When an alias is unique, Vault has to read a StoragePacker bucket, decompress it, unmarshal the protobuf, modify it, marshal it back to a protobuf, compress it, and write the bucket back. During any StoragePacker operation, a lock is put on that key which means that only one operation on the bucket can happen at any time. These operations are very expensive and get more expensive as the entity count grows.

Our entity count from the GCP auth backend is around 5 million currently, so each login results in processing ~22,300 entities in one of the StoragePacker buckets with an exclusive storage lock on that bucket. This results Vault failing if more than ~10 GCP authentications are being performed at a given time. We need to be able to do thousands per minute.

# Related Issues/Pull Requests
https://github.com/hashicorp/vault/issues/8761

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
