### PR TITLE
Allow auth metadata to be configured

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-hclog v0.12.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820
-	github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820
+	github.com/hashicorp/vault/sdk v0.1.14-0.20200424184458-ae3ba7f04ddc
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20200215195600-2ca765f0a500 h1:tiMX2ewq
 github.com/hashicorp/vault/sdk v0.1.14-0.20200215195600-2ca765f0a500/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
 github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820 h1:TmDZ1sS6gU0hFeFlFuyJVUwRPEzifZIHCBeS2WF2uSc=
 github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
+github.com/hashicorp/vault/sdk v0.1.14-0.20200424184458-ae3ba7f04ddc h1:7swTTVCN2DQrAaUForaV+ZksfjDwNMt463cYBH+J0C4=
+github.com/hashicorp/vault/sdk v0.1.14-0.20200424184458-ae3ba7f04ddc/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/plugin/gcp_role.go
+++ b/plugin/gcp_role.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/authmetadata"
 	"github.com/hashicorp/vault/sdk/helper/strutil"
 	"github.com/hashicorp/vault/sdk/helper/tokenutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -72,10 +73,12 @@ type gcpRole struct {
 	BoundLabels map[string]string `json:"bound_labels,omitempty"`
 
 	// IAMAliasType specifies the alias name to use with IAM roles. Can be either "unique_id" (default) or "role_id"
-	IAMAliasType string `json:"iam_alias,omitempty"`
+	IAMAliasType    string                `json:"iam_alias,omitempty"`
+	IAMAuthMetadata *authmetadata.Handler `json:"iam_auth_metadata_handler"`
 
 	// GCEAliasType specifies the alias name to use with GCE roles. Can be either "instance_id" (default) or "role_id"
-	GCEAliasType string `json:"gce_alias,omitempty"`
+	GCEAliasType    string                `json:"gce_alias,omitempty"`
+	GCEAuthMetadata *authmetadata.Handler `json:"gce_auth_metadata_handler"`
 
 	// Version indicates the version of this configuration. Allows for more advanced logic around
 	// upgrades and different behavior between config versions.

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -341,10 +341,11 @@ func (b *GcpAuthBackend) pathIamLogin(ctx context.Context, req *logical.Request,
 		Alias: &logical.Alias{
 			Name: alias,
 		},
-		Metadata:    authMetadata(loginInfo, serviceAccount),
 		DisplayName: serviceAccount.Email,
 	}
-
+	if err := role.IAMAuthMetadata.PopulateDesiredMetadata(auth, authMetadata(loginInfo, serviceAccount)); err != nil {
+		b.Logger().Warn("unable to set auth metadata", "err", err)
+	}
 	role.PopulateTokenAuth(auth)
 
 	resp := &logical.Response{
@@ -489,10 +490,11 @@ func (b *GcpAuthBackend) pathGceLogin(ctx context.Context, req *logical.Request,
 		Alias: &logical.Alias{
 			Name: alias,
 		},
-		Metadata:    authMetadata(loginInfo, serviceAccount),
 		DisplayName: instance.Name,
 	}
-
+	if err := role.GCEAuthMetadata.PopulateDesiredMetadata(auth, authMetadata(loginInfo, serviceAccount)); err != nil {
+		b.Logger().Warn("unable to set auth metadata", "err", err)
+	}
 	role.PopulateTokenAuth(auth)
 
 	resp := &logical.Response{

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,9 @@ import (
 
 func TestLogin_IAM(t *testing.T) {
 	t.Parallel()
+	if os.Getenv("GOOGLE_CREDENTIALS") == "" {
+		t.Skip("skipping because 'GOOGLE_CREDENTIALS' is unset")
+	}
 
 	b, storage, creds := testBackendWithCreds(t)
 	ctx := context.Background()

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestLogin_IAM(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("GOOGLE_CREDENTIALS") == "" {
-		t.Skip("skipping because 'GOOGLE_CREDENTIALS' is unset")
+	if os.Getenv(googleCredentialsEnv) == "" {
+		t.Skip(fmt.Sprintf("skipping because %q is unset", googleCredentialsEnv))
 	}
 
 	b, storage, creds := testBackendWithCreds(t)

--- a/plugin/path_role_test.go
+++ b/plugin/path_role_test.go
@@ -62,6 +62,7 @@ func TestRoleUpdateIam(t *testing.T) {
 		"name":                   roleName,
 		"type":                   iamRoleType,
 		"bound_service_accounts": strings.Join(serviceAccounts, ","),
+		"iam_metadata":           []string{"project_id"},
 	})
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"name":                   roleName,
@@ -70,9 +71,6 @@ func TestRoleUpdateIam(t *testing.T) {
 		"iam_alias":              defaultIAMAlias,
 		"iam_metadata": []string{
 			"project_id",
-			"role",
-			"service_account_id",
-			"service_account_email",
 		},
 	})
 
@@ -87,6 +85,7 @@ func TestRoleUpdateIam(t *testing.T) {
 		"allow_gce_inference":    false,
 		"add_group_aliases":      true,
 		"bound_service_accounts": strings.Join(serviceAccounts, ","),
+		"iam_metadata":           []string{"project_id", "role"},
 	})
 
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
@@ -104,12 +103,7 @@ func TestRoleUpdateIam(t *testing.T) {
 		"add_group_aliases":      true,
 		"bound_service_accounts": serviceAccounts,
 		"iam_alias":              defaultIAMAlias,
-		"iam_metadata": []string{
-			"project_id",
-			"role",
-			"service_account_id",
-			"service_account_email",
-		},
+		"iam_metadata":           []string{"project_id", "role"},
 	})
 }
 
@@ -256,8 +250,9 @@ func TestRoleGce(t *testing.T) {
 	roleName, projectId := testRoleAndProject(t)
 
 	testRoleCreate(t, b, reqStorage, map[string]interface{}{
-		"name": roleName,
-		"type": gceRoleType,
+		"name":         roleName,
+		"type":         gceRoleType,
+		"gce_metadata": "default",
 	})
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
 		"name":                   roleName,
@@ -291,6 +286,7 @@ func TestRoleGce(t *testing.T) {
 		"bound_labels":           "label1:foo,prod:true",
 		"bound_service_accounts": strings.Join(serviceAccounts, ","),
 		"add_group_aliases":      true,
+		"gce_metadata":           []string{},
 	})
 
 	testRoleRead(t, b, reqStorage, roleName, map[string]interface{}{
@@ -314,17 +310,7 @@ func TestRoleGce(t *testing.T) {
 		"bound_service_accounts": serviceAccounts,
 		"add_group_aliases":      true,
 		"gce_alias":              defaultGCEAlias,
-		"gce_metadata": []string{
-			"instance_creation_timestamp",
-			"instance_id",
-			"instance_name",
-			"project_id",
-			"project_number",
-			"role",
-			"service_account_id",
-			"service_account_email",
-			"zone",
-		},
+		"gce_metadata":           []string{},
 	})
 }
 

--- a/plugin/path_role_test.go
+++ b/plugin/path_role_test.go
@@ -68,6 +68,12 @@ func TestRoleUpdateIam(t *testing.T) {
 		"type":                   iamRoleType,
 		"bound_service_accounts": serviceAccounts,
 		"iam_alias":              defaultIAMAlias,
+		"iam_metadata": []string{
+			"project_id",
+			"role",
+			"service_account_id",
+			"service_account_email",
+		},
 	})
 
 	serviceAccounts = append(serviceAccounts, "testaccount@google.com")
@@ -98,6 +104,12 @@ func TestRoleUpdateIam(t *testing.T) {
 		"add_group_aliases":      true,
 		"bound_service_accounts": serviceAccounts,
 		"iam_alias":              defaultIAMAlias,
+		"iam_metadata": []string{
+			"project_id",
+			"role",
+			"service_account_id",
+			"service_account_email",
+		},
 	})
 }
 
@@ -129,6 +141,12 @@ func TestRoleIam_Wildcard(t *testing.T) {
 		"type":                   iamRoleType,
 		"bound_service_accounts": serviceAccounts,
 		"iam_alias":              defaultIAMAlias,
+		"iam_metadata": []string{
+			"project_id",
+			"role",
+			"service_account_id",
+			"service_account_email",
+		},
 	})
 }
 
@@ -152,6 +170,12 @@ func TestRoleIam_EditServiceAccounts(t *testing.T) {
 		"bound_projects":         projects,
 		"bound_service_accounts": initial,
 		"iam_alias":              defaultIAMAlias,
+		"iam_metadata": []string{
+			"project_id",
+			"role",
+			"service_account_id",
+			"service_account_email",
+		},
 	}
 
 	testRoleCreate(t, b, reqStorage, data)
@@ -241,6 +265,17 @@ func TestRoleGce(t *testing.T) {
 		"bound_projects":         []string{},
 		"bound_service_accounts": []string{},
 		"gce_alias":              defaultGCEAlias,
+		"gce_metadata": []string{
+			"instance_creation_timestamp",
+			"instance_id",
+			"instance_name",
+			"project_id",
+			"project_number",
+			"role",
+			"service_account_id",
+			"service_account_email",
+			"zone",
+		},
 	})
 
 	serviceAccounts := []string{"aserviceaccountid", "testaccount@google.com"}
@@ -279,6 +314,17 @@ func TestRoleGce(t *testing.T) {
 		"bound_service_accounts": serviceAccounts,
 		"add_group_aliases":      true,
 		"gce_alias":              defaultGCEAlias,
+		"gce_metadata": []string{
+			"instance_creation_timestamp",
+			"instance_id",
+			"instance_name",
+			"project_id",
+			"project_number",
+			"role",
+			"service_account_id",
+			"service_account_email",
+			"zone",
+		},
 	})
 }
 
@@ -305,6 +351,17 @@ func TestRoleGce_EditLabels(t *testing.T) {
 		"bound_projects": []string{projectId},
 		"bound_labels":   labels,
 		"gce_alias":      defaultGCEAlias,
+		"gce_metadata": []string{
+			"instance_creation_timestamp",
+			"instance_id",
+			"instance_name",
+			"project_id",
+			"project_number",
+			"role",
+			"service_account_id",
+			"service_account_email",
+			"zone",
+		},
 	})
 
 	testRoleEditLabels(t, b, reqStorage, map[string]interface{}{
@@ -319,6 +376,17 @@ func TestRoleGce_EditLabels(t *testing.T) {
 		"bound_projects": []string{projectId},
 		"bound_labels":   labels,
 		"gce_alias":      defaultGCEAlias,
+		"gce_metadata": []string{
+			"instance_creation_timestamp",
+			"instance_id",
+			"instance_name",
+			"project_id",
+			"project_number",
+			"role",
+			"service_account_id",
+			"service_account_email",
+			"zone",
+		},
 	})
 
 	testRoleEditLabels(t, b, reqStorage, map[string]interface{}{
@@ -335,6 +403,17 @@ func TestRoleGce_EditLabels(t *testing.T) {
 		"bound_projects": []string{projectId},
 		"bound_labels":   labels,
 		"gce_alias":      defaultGCEAlias,
+		"gce_metadata": []string{
+			"instance_creation_timestamp",
+			"instance_id",
+			"instance_name",
+			"project_id",
+			"project_number",
+			"role",
+			"service_account_id",
+			"service_account_email",
+			"zone",
+		},
 	})
 }
 
@@ -367,6 +446,17 @@ func TestRoleGce_DeprecatedFields(t *testing.T) {
 			"bound_zones":           []string{"us-east1-a"},
 			"bound_instance_groups": []string{"my-ig"},
 			"gce_alias":             defaultGCEAlias,
+			"gce_metadata": []string{
+				"instance_creation_timestamp",
+				"instance_id",
+				"instance_name",
+				"project_id",
+				"project_number",
+				"role",
+				"service_account_id",
+				"service_account_email",
+				"zone",
+			},
 		})
 	})
 

--- a/vendor/github.com/hashicorp/vault/sdk/helper/authmetadata/auth_metadata.go
+++ b/vendor/github.com/hashicorp/vault/sdk/helper/authmetadata/auth_metadata.go
@@ -1,0 +1,196 @@
+package authmetadata
+
+/*
+	authmetadata is a package offering convenience and
+	standardization when supporting an `auth_metadata`
+	field in a plugin's configuration. This then controls
+	what metadata is added to an Auth during login.
+
+	To see an example of how to add and use it, check out
+	how these structs and fields are used in the AWS auth
+	method.
+
+	Or, check out its acceptance test in this package to
+	see its integration points.
+*/
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// Fields is for configuring a back-end's available
+// default and additional fields. These are used for
+// providing a verbose field description, and for parsing
+// user input.
+type Fields struct {
+	// The field name as it'll be reflected in the user-facing
+	// schema.
+	FieldName string
+
+	// Default is a list of the default fields that should
+	// be included if a user sends "default" in their list
+	// of desired fields. These fields should all have a
+	// low rate of change because each change can incur a
+	// write to storage.
+	Default []string
+
+	// AvailableToAdd is a list of fields not included by
+	// default, that the user may include.
+	AvailableToAdd []string
+}
+
+func (f *Fields) all() []string {
+	return append(f.Default, f.AvailableToAdd...)
+}
+
+// FieldSchema takes the default and additionally available
+// fields, and uses them to generate a verbose description
+// regarding how to use the "auth_metadata" field.
+func FieldSchema(fields *Fields) *framework.FieldSchema {
+	return &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: description(fields),
+		DisplayAttrs: &framework.DisplayAttributes{
+			Name:  fields.FieldName,
+			Value: "field1,field2",
+		},
+		Default: []string{"default"},
+	}
+}
+
+func NewHandler(fields *Fields) *Handler {
+	return &Handler{
+		fields: fields,
+	}
+}
+
+type Handler struct {
+	// authMetadata is an explicit list of all the user's configured
+	// fields that are being added to auth metadata. If it is set to
+	// default or unconfigured, it will be nil. Otherwise, it will
+	// hold the explicit fields set by the user.
+	authMetadata []string
+
+	// fields is a list of the configured default and available
+	// fields.
+	fields *Fields
+}
+
+// AuthMetadata is intended to be used on config reads.
+// It gets an explicit list of all the user's configured
+// fields that are being added to auth metadata.
+func (h *Handler) AuthMetadata() []string {
+	if h.authMetadata == nil {
+		return h.fields.Default
+	}
+	return h.authMetadata
+}
+
+// ParseAuthMetadata is intended to be used on config create/update.
+// It takes a user's selected fields (or lack thereof),
+// converts it to a list of explicit fields, and adds it to the Handler
+// for later storage.
+func (h *Handler) ParseAuthMetadata(data *framework.FieldData) error {
+	userProvidedRaw, ok := data.GetOk(h.fields.FieldName)
+	if !ok {
+		// Nothing further to do here.
+		return nil
+	}
+	userProvided, ok := userProvidedRaw.([]string)
+	if !ok {
+		return fmt.Errorf("%s is an unexpected type of %T", userProvidedRaw, userProvidedRaw)
+	}
+	userProvided = strutil.RemoveDuplicates(userProvided, true)
+
+	// If the only field the user has chosen was the default field,
+	// we don't store anything so we won't have to do a storage
+	// migration if the default changes.
+	if len(userProvided) == 1 && userProvided[0] == "default" {
+		h.authMetadata = nil
+		return nil
+	}
+
+	// Validate and store the input.
+	if strutil.StrListContains(userProvided, "default") {
+		return fmt.Errorf("%q contains default - default can't be used in combination with other fields",
+			userProvided)
+	}
+	if !strutil.StrListSubset(h.fields.all(), userProvided) {
+		return fmt.Errorf("%q contains an unavailable field, please select from %q",
+			strings.Join(userProvided, ", "), strings.Join(h.fields.all(), ", "))
+	}
+	h.authMetadata = userProvided
+	return nil
+}
+
+// PopulateDesiredMetadata is intended to be used during login
+// just before returning an auth.
+// It takes the available auth metadata and,
+// if the auth should have it, adds it to the auth's metadata.
+func (h *Handler) PopulateDesiredMetadata(auth *logical.Auth, available map[string]string) error {
+	if auth == nil {
+		return errors.New("auth is nil")
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]string)
+	}
+	if auth.Alias == nil {
+		auth.Alias = &logical.Alias{}
+	}
+	if auth.Alias.Metadata == nil {
+		auth.Alias.Metadata = make(map[string]string)
+	}
+	fieldsToInclude := h.fields.Default
+	if h.authMetadata != nil {
+		fieldsToInclude = h.authMetadata
+	}
+	for availableField, itsValue := range available {
+		if strutil.StrListContains(fieldsToInclude, availableField) {
+			auth.Metadata[availableField] = itsValue
+			auth.Alias.Metadata[availableField] = itsValue
+		}
+	}
+	return nil
+}
+
+func (h *Handler) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		AuthMetadata []string `json:"auth_metadata"`
+	}{
+		AuthMetadata: h.authMetadata,
+	})
+}
+
+func (h *Handler) UnmarshalJSON(data []byte) error {
+	jsonable := &struct {
+		AuthMetadata []string `json:"auth_metadata"`
+	}{
+		AuthMetadata: h.authMetadata,
+	}
+	if err := json.Unmarshal(data, jsonable); err != nil {
+		return err
+	}
+	h.authMetadata = jsonable.AuthMetadata
+	return nil
+}
+
+func description(fields *Fields) string {
+	desc := "The metadata to include on the aliases and audit logs generated by this plugin."
+	if len(fields.Default) > 0 {
+		desc += fmt.Sprintf(" When set to 'default', includes: %s.", strings.Join(fields.Default, ", "))
+	}
+	if len(fields.AvailableToAdd) > 0 {
+		desc += fmt.Sprintf(" These fields are available to add: %s.", strings.Join(fields.AvailableToAdd, ", "))
+	}
+	desc += " Not editing this field means the 'default' fields are included." +
+		" Explicitly setting this field to empty overrides the 'default' and means no metadata will be included." +
+		" If not using 'default', explicit fields must be sent like: 'field1,field2'."
+	return desc
+}


### PR DESCRIPTION
This draft PR shows the approach being currently pursued to add the ability to configure auth metadata at the role level.

Although it was added at the `identity/config` endpoint in a different auth engine, it was added at the role level in this one because that's where the aliases are also currently configured, so I thought it made sense to keep them together.

TODO
- [ ] Docs
- [ ] Wait for https://github.com/hashicorp/vault/pull/8783 to be merged and update to using Vault master