### PR TITLE
Changes the default alias names to role_id for both IAM and GCE authn

### DIFF
--- a/plugin/aliasing.go
+++ b/plugin/aliasing.go
@@ -13,22 +13,22 @@ type iamAliaser func(role *gcpRole, svcAccount *iam.ServiceAccount) (alias strin
 type gceAliaser func(role *gcpRole, instance *compute.Instance) (alias string)
 
 const (
-	defaultIAMAlias = "unique_id"
-	defaultGCEAlias = "instance_id"
+	defaultIAMAlias = "role_id"
+	defaultGCEAlias = "role_id"
 )
 
 var (
 	allowedIAMAliases = map[string]iamAliaser{
-		defaultIAMAlias: getIAMSvcAccountUniqueID,
-		"":              getIAMSvcAccountUniqueID, // For backwards compatibility
+		defaultIAMAlias: getIAMRoleID,
+		"":              getIAMRoleID, // For backwards compatibility
 
-		"role_id": getIAMRoleID,
+		"unique_id": getIAMSvcAccountUniqueID,
 	}
 	allowedGCEAliases = map[string]gceAliaser{
-		defaultGCEAlias: getGCEInstanceID,
-		"":              getGCEInstanceID, // For backwards compatibility
+		defaultGCEAlias: getGCERoleID,
+		"":              getGCERoleID, // For backwards compatibility
 
-		"role_id": getGCERoleID,
+		"instance_id": getGCEInstanceID,
 	}
 
 	allowedIAMAliasesSlice = iamMapKeyToSlice(allowedIAMAliases)

--- a/plugin/gcp_config.go
+++ b/plugin/gcp_config.go
@@ -90,12 +90,7 @@ func (c *gcpConfig) Update(d *framework.FieldData) error {
 }
 
 func (c *gcpConfig) getIAMAlias(role *gcpRole, svcAccount *iam.ServiceAccount) (alias string, err error) {
-	aliasType := c.IAMAliasType
-	if aliasType == "" {
-		aliasType = defaultIAMAlias
-	}
-
-	aliaser, exists := allowedIAMAliases[aliasType]
+	aliaser, exists := allowedIAMAliases[c.IAMAliasType]
 	if !exists {
 		return "", fmt.Errorf("invalid IAM alias type: must be one of: %s", strings.Join(allowedIAMAliasesSlice, ", "))
 	}
@@ -103,12 +98,7 @@ func (c *gcpConfig) getIAMAlias(role *gcpRole, svcAccount *iam.ServiceAccount) (
 }
 
 func (c *gcpConfig) getGCEAlias(role *gcpRole, instance *compute.Instance) (alias string, err error) {
-	aliasType := c.GCEAliasType
-	if aliasType == "" {
-		aliasType = defaultGCEAlias
-	}
-
-	aliaser, exists := allowedGCEAliases[aliasType]
+	aliaser, exists := allowedGCEAliases[c.GCEAliasType]
 	if !exists {
 		return "", fmt.Errorf("invalid GCE alias type: must be one of: %s", strings.Join(allowedGCEAliasesSlice, ", "))
 	}

--- a/plugin/gcp_config_test.go
+++ b/plugin/gcp_config_test.go
@@ -40,7 +40,7 @@ func TestGetIAMAlias(t *testing.T) {
 			svcAccount: &iam.ServiceAccount{
 				UniqueId: "iamUniqueID",
 			},
-			expectedAlias: "iamUniqueID",
+			expectedAlias: "testRoleID",
 			expectErr:     false,
 		},
 		"default type": {
@@ -53,12 +53,12 @@ func TestGetIAMAlias(t *testing.T) {
 			svcAccount: &iam.ServiceAccount{
 				UniqueId: "iamUniqueID",
 			},
-			expectedAlias: "iamUniqueID",
+			expectedAlias: "testRoleID",
 			expectErr:     false,
 		},
-		"role_id": {
+		"unique_id": {
 			config: &gcpConfig{
-				IAMAliasType: "role_id",
+				IAMAliasType: "unique_id",
 			},
 			role: &gcpRole{
 				RoleID: "testRoleID",
@@ -66,7 +66,7 @@ func TestGetIAMAlias(t *testing.T) {
 			svcAccount: &iam.ServiceAccount{
 				UniqueId: "iamUniqueID",
 			},
-			expectedAlias: "testRoleID",
+			expectedAlias: "iamUniqueID",
 			expectErr:     false,
 		},
 	}
@@ -120,7 +120,7 @@ func TestGetGCEAlias(t *testing.T) {
 			instance: &compute.Instance{
 				Id: 123,
 			},
-			expectedAlias: "gce-123",
+			expectedAlias: "testRoleID",
 			expectErr:     false,
 		},
 		"default type": {
@@ -133,12 +133,12 @@ func TestGetGCEAlias(t *testing.T) {
 			instance: &compute.Instance{
 				Id: 123,
 			},
-			expectedAlias: "gce-123",
+			expectedAlias: "testRoleID",
 			expectErr:     false,
 		},
-		"role_id": {
+		"instance_id": {
 			config: &gcpConfig{
-				GCEAliasType: "role_id",
+				GCEAliasType: "instance_id",
 			},
 			role: &gcpRole{
 				RoleID: "testRoleID",
@@ -146,7 +146,7 @@ func TestGetGCEAlias(t *testing.T) {
 			instance: &compute.Instance{
 				Id: 123,
 			},
-			expectedAlias: "testRoleID",
+			expectedAlias: "gce-123",
 			expectErr:     false,
 		},
 	}

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -34,6 +34,8 @@ func TestLogin_IAM(t *testing.T) {
 
 	// defaultRole fills in values unless they are already filled in
 	defaultRole := func(r *gcpRole) *gcpRole {
+		r.RoleID = "testRoleID"
+
 		if r.RoleType == "" {
 			r.RoleType = "iam"
 		}
@@ -213,7 +215,7 @@ func TestLogin_IAM(t *testing.T) {
 
 			if tc.exp != nil && tc.exp.Auth != nil {
 				tc.exp.Auth.Alias = &logical.Alias{
-					Name: creds.ClientId,
+					Name: tc.role.RoleID,
 				}
 				tc.exp.Auth.DisplayName = creds.ClientEmail
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,6 +60,7 @@ github.com/hashicorp/hcl/json/token
 github.com/hashicorp/vault/api
 # github.com/hashicorp/vault/sdk v0.1.14-0.20200427170607-03332aaf8d18
 github.com/hashicorp/vault/sdk/framework
+github.com/hashicorp/vault/sdk/helper/authmetadata
 github.com/hashicorp/vault/sdk/helper/certutil
 github.com/hashicorp/vault/sdk/helper/cidrutil
 github.com/hashicorp/vault/sdk/helper/compressutil


### PR DESCRIPTION
# Overview

This PR changes the default name of the entity alias that gets created for both IAM and GCE authentication. Test fixes are also included in this PR. See test output below.

For IAM, changes it from `unique_id ` to `role_id`.
For GCE, change it from `instance_id ` to `role_id`.

Docs PR: https://github.com/hashicorp/vault/pull/9494

# Design of Change

Change was implemented using alias configuration made available in https://github.com/hashicorp/vault-plugin-auth-gcp/pull/89.

# Related Issues/Pull Requests
- https://github.com/hashicorp/vault-plugin-auth-gcp/pull/89

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Backwards compatible
    - This is an intentional change that will be included in a CHANGES entry in the Vault CHANGELOG.
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)

```
$ export GOOGLE_CREDENTIALS="$(cat /Users/austingebauer/.gcp/austin-gebauer-db62ff1c96b4.json)"
$ make test                                                                                    
?       github.com/hashicorp/vault-plugin-auth-gcp      [no test files]
ok      github.com/hashicorp/vault-plugin-auth-gcp/plugin       (cached)
?       github.com/hashicorp/vault-plugin-auth-gcp/plugin/cache [no test files]
$ echo $?
0
```
