### PR TITLE
String was being passed in sprintf format instead of as Wrapf param

### DIFF
--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -173,7 +173,7 @@ func (b *GcpAuthBackend) parseAndValidateJwt(ctx context.Context, req *logical.R
 
 	key, err := b.getSigningKey(ctx, jwtVal, signedJwt.(string), loginInfo.Role, req.Storage)
 	if err != nil {
-		return nil, errwrap.Wrapf("unable to get public key for signed JWT: %v", err)
+		return nil, errwrap.Wrapf("unable to get public key for signed JWT: {{err}}", err)
 	}
 
 	// Parse claims and verify signature.


### PR DESCRIPTION
# Overview
Super minor change. We're having an issue with auth that is likely environmental but the error we're getting is `* unable to get public key for signed JWT: %v`. It would be much more helpful if we received the actual error instead of %v. 

# Design of Change
Verified that errwrap.Wrapf replaces {{err}}, not %v and updated call to match.

# Related Issues/Pull Requests
No related issue, simply something I noticed while troubleshooting an environmental issue.

# Contributor Checklist
No tests were run, frankly, I didn't do any verification except to check that Wrapf is expecting {{err}} which you can see in the function itself and just a few lines before the changed line in another call to Wrapf
