### PR TITLE
Update plugin-backport workflow to work with label events

### DIFF
--- a/.github/workflows/vault-plugin-backport.yml
+++ b/.github/workflows/vault-plugin-backport.yml
@@ -4,6 +4,7 @@
     pull_request_target:
       types:
         - closed
+        - labeled
   
   jobs:
     backport:


### PR DESCRIPTION
This PR changes our installed backporter workflow to also run when merged PRs are labeled. 