### PR TITLE
Fix error in renewal test

### DIFF
--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -280,12 +280,12 @@ func Test_Renew(t *testing.T) {
 	b, storage, creds := testBackendWithCreds(t)
 
 	// Build the JWT token
-	iamClient, err := b.IAMClient(storage)
+	iamClient, err := b.IAMCredentialsClient(storage)
 	if err != nil {
 		t.Fatal(err)
 	}
 	exp := time.Now().Add(10 * time.Minute)
-	jwt, err := ServiceAccountLoginJwt(iamClient, exp, "vault/test", creds.ProjectId, creds.ClientEmail)
+	jwt, err := ServiceAccountLoginJwt(iamClient, exp, "vault/test", creds.ClientEmail)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#82 introduced a small bug in a new test by using the wrong type and too many arguments to the `ServiceAccountLoginJwt` function.