### PR TITLE
Fix config reset to application default credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+BUG FIXES:
+
+* Fixes the ability to reset the configuration's credentials to use application default credentials [[GH-132](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/132)]
+
 IMPROVEMENTS:
 
 * Updates dependencies: `google.golang.org/api@v0.83.0`, `github.com/hashicorp/go-gcp-common@v0.8.0` [[GH-130](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/130)]

--- a/plugin/gcp_config.go
+++ b/plugin/gcp_config.go
@@ -61,16 +61,24 @@ func (c *gcpConfig) Update(d *framework.FieldData) error {
 	}
 
 	if v, ok := d.GetOk("credentials"); ok {
-		creds, err := gcputil.Credentials(v.(string))
-		if err != nil {
-			return fmt.Errorf("failed to read credentials: %w", err)
-		}
+		credentials := v.(string)
 
-		if len(creds.PrivateKeyId) == 0 {
-			return errors.New("missing private key in credentials")
-		}
+		// If the given credentials are empty, reset them so that application default
+		// credentials are used. Otherwise, parse and validate the given credentials.
+		if credentials == "" {
+			c.Credentials = nil
+		} else {
+			creds, err := gcputil.Credentials(credentials)
+			if err != nil {
+				return fmt.Errorf("failed to read credentials: %w", err)
+			}
 
-		c.Credentials = creds
+			if len(creds.PrivateKeyId) == 0 {
+				return errors.New("missing private key in credentials")
+			}
+
+			c.Credentials = creds
+		}
 	}
 
 	rawIamAlias, exists := d.GetOk("iam_alias")


### PR DESCRIPTION
## Overview

This PR fixes the ability to reset the configuration's credentials to use application default credentials. Prior to this change, it wasn't possible to update the config to begin using application default credentials again.

Fixes https://github.com/hashicorp/vault-plugin-auth-gcp/issues/131.

## Testing

I've added a couple of test cases to this PR. I also successfully ran all acceptance tests.