### PR TITLE
Backport 1.11.x: Fix config reset to application default credentials (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
-## Unreleased
+## Next
+
+BUG FIXES:
+
+* Fixes the ability to reset the configuration's credentials to use application default credentials [[GH-132](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/132)]
+
+IMPROVEMENTS:
+
+* Updates dependencies: `google.golang.org/api@v0.83.0`, `github.com/hashicorp/go-gcp-common@v0.8.0` [[GH-130](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/130)]
+
+## v0.13.0
 
 IMPROVEMENTS:
 * Vault CLI now infers the service account email when running on Google Cloud [[GH-115](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/115)]
 * Enable the Google service endpoints used by the underlying client to be customized [[GH-126](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/126)]
 
-## 0.11.3
+## v0.11.3
 
 BUG FIXES:
 * Fix token renewals when TokenPolicies have been configured [[GH-82](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/82)]

--- a/plugin/gcp_config.go
+++ b/plugin/gcp_config.go
@@ -61,16 +61,24 @@ func (c *gcpConfig) Update(d *framework.FieldData) error {
 	}
 
 	if v, ok := d.GetOk("credentials"); ok {
-		creds, err := gcputil.Credentials(v.(string))
-		if err != nil {
-			return fmt.Errorf("failed to read credentials: %w", err)
-		}
+		credentials := v.(string)
 
-		if len(creds.PrivateKeyId) == 0 {
-			return errors.New("missing private key in credentials")
-		}
+		// If the given credentials are empty, reset them so that application default
+		// credentials are used. Otherwise, parse and validate the given credentials.
+		if credentials == "" {
+			c.Credentials = nil
+		} else {
+			creds, err := gcputil.Credentials(credentials)
+			if err != nil {
+				return fmt.Errorf("failed to read credentials: %w", err)
+			}
 
-		c.Credentials = creds
+			if len(creds.PrivateKeyId) == 0 {
+				return errors.New("missing private key in credentials")
+			}
+
+			c.Credentials = creds
+		}
 	}
 
 	rawIamAlias, exists := d.GetOk("iam_alias")


### PR DESCRIPTION
This PR backports a bug fix from #132.

Steps:
1. `git checkout release/vault-1.11.x`
2. `git checkout -b backport-pr-132-1.11.x`
3. `git cherry-pick 54acedf4f4f62331e75ca64dcc0ca52c57d226d7`