### PR TITLE
Backport 1.10.x: Fix config reset to application default credentials (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
-## 0.11.3
-### Unreleased
+## Next
 
 BUG FIXES:
 
+* Fixes the ability to reset the configuration's credentials to use application default credentials [[GH-132](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/132)]
+
+IMPROVEMENTS:
+
+* Updates dependencies: `google.golang.org/api@v0.83.0`, `github.com/hashicorp/go-gcp-common@v0.8.0` [[GH-130](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/130)]
+
+## v0.13.0
+
+IMPROVEMENTS:
+* Vault CLI now infers the service account email when running on Google Cloud [[GH-115](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/115)]
+* Enable the Google service endpoints used by the underlying client to be customized [[GH-126](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/126)]
+
+## v0.11.3
+
+BUG FIXES:
 * Fix token renewals when TokenPolicies have been configured [[GH-82](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/82)]

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -269,57 +269,35 @@ func TestConfig_Update(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name    string
-		new     *gcpConfig
-		d       *framework.FieldData
-		r       *gcpConfig
-		changed bool
-		err     bool
+		name      string
+		fieldData *framework.FieldData
+		original  *gcpConfig
+		expected  *gcpConfig
+		wantErr   bool
 	}{
 		{
-			"empty",
-			&gcpConfig{
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
-			},
-			nil,
-			&gcpConfig{
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
-			},
-			false,
-			false,
+			name:      "empty",
+			fieldData: nil,
+			original:  &gcpConfig{},
+			expected:  &gcpConfig{},
 		},
 		{
-			"keeps_existing",
-			&gcpConfig{
+			name:      "keeps_existing",
+			fieldData: nil,
+			original: &gcpConfig{
 				Credentials: &gcputil.GcpCredentials{
 					ClientId: "foo",
 				},
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
 			},
-			nil,
-			&gcpConfig{
+			expected: &gcpConfig{
 				Credentials: &gcputil.GcpCredentials{
 					ClientId: "foo",
 				},
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
 			},
-			false,
-			false,
 		},
 		{
-			"overwrites_changes",
-			&gcpConfig{
-				Credentials: &gcputil.GcpCredentials{
-					ClientId: "foo",
-				},
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
-			},
-			&framework.FieldData{
+			name: "overwrites_changes",
+			fieldData: &framework.FieldData{
 				Raw: map[string]interface{}{
 					"credentials": `{
 						"client_id": "bar",
@@ -327,27 +305,21 @@ func TestConfig_Update(t *testing.T) {
 					}`,
 				},
 			},
-			&gcpConfig{
+			original: &gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			expected: &gcpConfig{
 				Credentials: &gcputil.GcpCredentials{
 					ClientId:     "bar",
 					PrivateKeyId: "aaa",
 				},
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
 			},
-			true,
-			false,
 		},
 		{
-			"overwrites_and_new",
-			&gcpConfig{
-				Credentials: &gcputil.GcpCredentials{
-					ClientId: "foo",
-				},
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
-			},
-			&framework.FieldData{
+			name: "overwrites_and_new",
+			fieldData: &framework.FieldData{
 				Raw: map[string]interface{}{
 					"credentials": `{
 						"client_id": "foo",
@@ -355,16 +327,52 @@ func TestConfig_Update(t *testing.T) {
 					}`,
 				},
 			},
-			&gcpConfig{
+			original: &gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			expected: &gcpConfig{
 				Credentials: &gcputil.GcpCredentials{
 					ClientId:     "foo",
 					PrivateKeyId: "aaa",
 				},
-				GCEAuthMetadata: authmetadata.NewHandler(gceAuthMetadataFields),
-				IAMAuthMetadata: authmetadata.NewHandler(iamAuthMetadataFields),
 			},
-			true,
-			false,
+		},
+		{
+			name: "empty credentials resets to use application default credentials",
+			fieldData: &framework.FieldData{
+				Raw: map[string]interface{}{
+					"credentials": "",
+				},
+			},
+			original: &gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			expected: &gcpConfig{
+				Credentials: nil,
+			},
+		},
+		{
+			name: "invalid credentials results in error and retains original credentials",
+			fieldData: &framework.FieldData{
+				Raw: map[string]interface{}{
+					"credentials": "{}",
+				},
+			},
+			original: &gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			expected: &gcpConfig{
+				Credentials: &gcputil.GcpCredentials{
+					ClientId: "foo",
+				},
+			},
+			wantErr: true,
 		},
 	}
 
@@ -372,23 +380,25 @@ func TestConfig_Update(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			tc.original.GCEAuthMetadata = authmetadata.NewHandler(gceAuthMetadataFields)
+			tc.original.IAMAuthMetadata = authmetadata.NewHandler(gceAuthMetadataFields)
 
-			if tc.d != nil {
+			if tc.fieldData != nil {
 				var b GcpAuthBackend
-				tc.d.Schema = pathConfig(&b).Fields
+				tc.fieldData.Schema = pathConfig(&b).Fields
 			}
 
-			err := tc.new.Update(tc.d)
-			if tc.err && err == nil {
+			err := tc.original.Update(tc.fieldData)
+			if tc.wantErr && err == nil {
 				t.Fatalf("err expected, got nil")
 			}
-			if !tc.err && err != nil {
+			if !tc.wantErr && err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
 
-			if v, exp := tc.new.Credentials, tc.r.Credentials; !reflect.DeepEqual(v, exp) {
-				t.Errorf("expected %q to be %q", v, exp)
+			if !reflect.DeepEqual(tc.original.Credentials, tc.expected.Credentials) {
+				t.Errorf("expected %+v to be %+v", tc.original.Credentials,
+					tc.expected.Credentials)
 			}
 		})
 	}


### PR DESCRIPTION
This PR backports a bug fix from #132.

Steps:
1. `git checkout release/vault-1.10.x`
2. `git checkout -b backport-pr-132-1.10.x`
3. `git cherry-pick 54acedf4f4f62331e75ca64dcc0ca52c57d226d7`