### PR TITLE
Remove gopkg.in/square/go-jose.v2 dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ IMPROVEMENTS:
    * `github.com/stretchr/testify` v1.8.4 -> v1.9.0
    * `golang.org/x/oauth2` v0.16.0 -> v0.19.0
    * `google.golang.org/api` v0.161.0 -> v0.172.0
-* Upgrade `github.com/go-jose/go-jose/v3` to `github.com/go-jose/go-jose/v4` 4.0.1: [GH-202](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/202)
+* Upgrade `gopkg.in/square/go-jose.v2` and `github.com/go-jose/go-jose/v3` to `github.com/go-jose/go-jose/v4` 4.0.1: [GH-202](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/202), [GH-203](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/203)
 * Bump `google.golang.org/protobuf` from 1.32.0 to 1.33.0: [GH-197](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/197)
 * Bump `github.com/docker/docker` from 24.0.7+incompatible to 24.0.9+incompatible: [GH-198](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/198)
 * Bump `golang.org/x/net` from 0.22.0 to 0.24.0: [GH-201](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/201)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.2
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0
+	github.com/go-jose/go-jose/v4 v4.0.1
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-gcp-common v0.8.0
@@ -18,7 +19,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.19.0
 	google.golang.org/api v0.172.0
-	gopkg.in/square/go-jose.v2 v2.6.0
 )
 
 require (
@@ -34,7 +34,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
-gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -33,6 +33,8 @@ const (
 var (
 	allowedSignatureAlgorithms = []jose.SignatureAlgorithm{
 		jose.RS256,
+		jose.ES256,
+		jose.HS256,
 	}
 )
 

--- a/plugin/path_login_test.go
+++ b/plugin/path_login_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -20,8 +22,6 @@ import (
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/iamcredentials/v1"
 	"google.golang.org/api/option"
-	jose "gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func TestRoleResolution(t *testing.T) {
@@ -674,7 +674,7 @@ func testCreateExpiredJwtToken(tb testing.TB, roleName string, creds *gcputil.Gc
 			Subject:  creds.ClientId,
 			Audience: []string{fmt.Sprintf(expectedJwtAudTemplate, roleName)},
 			Expiry:   jwt.NewNumericDate(time.Now().Add(-100 * time.Minute)),
-		}).CompactSerialize()
+		}).Serialize()
 	if err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
There is no fix for the [GO-2024-2631](https://pkg.go.dev/vuln/GO-2024-2631) vuln for `gopkg.in/square/go-jose.v2`, so now seems like a good time to remove it from the dependencies and standardise on the latest v4 version of the module.

Unfortunately it does mean we need to be more selective about the signature algorithms we allow when receiving a JWT during a login request. I think RS256 is the correct choice based on empirical evidence, but I do have concerns that there's no public commitment to that signature algorithm in Google's docs, so it's possible they could change this signature algorithm at any point.

References:
* Explainer for how JWTs relate to the auth method: https://developer.hashicorp.com/vault/docs/auth/gcp#generating-jwts
* PR that addressed the CVE and introduced the requirement for a limited set of supported signature algorithms: https://github.com/go-jose/go-jose/pull/74
* Google API docs for generating the JWT in question: https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt