### PR TITLE
WIF support for GCP auth engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+IMPROVEMENTS:
+* Added support for Workload Identity Federation [GH-204](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/204)
+
 ## v0.16.3
 
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.0.1
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/hashicorp/go-gcp-common v0.8.0
+	github.com/hashicorp/go-gcp-common v0.9.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-gcp-common v0.8.0 h1:/2vGAbCU1v+BZ3YHXTCzTvxqma9WOJHYtADTfhZixLo=
-github.com/hashicorp/go-gcp-common v0.8.0/go.mod h1:Q7zYRy9ue9SuaEN2s9YLIQs4SoKHdoRmKRcImY3SLgs=
+github.com/hashicorp/go-gcp-common v0.9.0 h1:dabqPrA+vlNWcyQV/3yOI6WCmQGFJgwyztDEsqDp+Q0=
+github.com/hashicorp/go-gcp-common v0.9.0/go.mod h1:aZnN6BVMqryPo4vIy97ZAYSoREnJWilLMmaOmi5P7vY=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -268,7 +268,7 @@ func (b *GcpAuthBackend) credentials(ctx context.Context, s logical.Storage) (*g
 }
 
 func (b *GcpAuthBackend) GetExternalAccountConfig(c *gcpConfig, ts *PluginIdentityTokenSupplier) *gcputil.ExternalAccountConfig {
-	b.Logger().Info("adding web identity token fetcher")
+	b.Logger().Debug("adding web identity token fetcher")
 	cfg := &gcputil.ExternalAccountConfig{
 		ServiceAccountEmail: c.ServiceAccountEmail,
 		Audience:            c.IdentityTokenAudience,

--- a/plugin/cli.go
+++ b/plugin/cli.go
@@ -104,9 +104,15 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		mount = "gcp"
 	}
 
-	loginToken, err := getSignedJwt(role, m)
-	if err != nil {
-		return nil, err
+	var loginToken string
+	var err error
+	if v, ok := m["jwt"]; ok {
+		loginToken = v
+	} else {
+		loginToken, err = getSignedJwt(role, m)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	path := fmt.Sprintf("auth/%s/login", mount)

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -6,11 +6,13 @@ package gcpauth
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/authmetadata"
+	"github.com/hashicorp/vault/sdk/helper/pluginutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -455,5 +457,116 @@ func TestConfig_Update(t *testing.T) {
 					tc.expected.Credentials)
 			}
 		})
+	}
+}
+
+type testSystemView struct {
+	logical.StaticSystemView
+}
+
+func (d testSystemView) GenerateIdentityToken(_ context.Context, _ *pluginutil.IdentityTokenRequest) (*pluginutil.IdentityTokenResponse, error) {
+	return &pluginutil.IdentityTokenResponse{}, nil
+}
+
+// TestConfig_PluginIdentityToken tests that configuring WIF succeeds
+// It uses the testSystemView interface to generate the ID token
+func TestConfig_PluginIdentityToken(t *testing.T) {
+	config := logical.TestBackendConfig()
+	config.StorageView = &logical.InmemStorage{}
+	config.System = &testSystemView{}
+
+	b := Backend()
+	if err := b.Setup(context.Background(), config); err != nil {
+		t.Fatal(err)
+	}
+
+	configData := map[string]interface{}{
+		"identity_token_ttl":      int64(10),
+		"identity_token_audience": "test-aud",
+		"service_account_email":   "test-service_account",
+	}
+
+	configReq := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   config.StorageView,
+		Path:      "config",
+		Data:      configData,
+	}
+
+	resp, err := b.HandleRequest(context.Background(), configReq)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: config writing failed: resp:%#v\n err: %v", resp, err)
+	}
+
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Storage:   config.StorageView,
+		Path:      "config",
+	})
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("bad: config reading failed: resp:%#v\n err: %v", resp, err)
+	}
+
+	// Grab the subset of fields from the response we care to look at for this case
+	got := map[string]interface{}{
+		"identity_token_ttl":      resp.Data["identity_token_ttl"],
+		"identity_token_audience": resp.Data["identity_token_audience"],
+		"service_account_email":   resp.Data["service_account_email"],
+	}
+
+	if !reflect.DeepEqual(got, configData) {
+		t.Errorf("bad: expected to read config root as %#v, got %#v instead", configData, resp.Data)
+	}
+
+	credJson := `{
+				  "project_id": "project_id",
+				  "private_key_id": "key_id",
+				  "private_key": "key",
+				  "client_email": "user@test.com",
+				  "client_id": "client_id"
+				}`
+	// mutually exclusive fields must result in an error
+	configData = map[string]interface{}{
+		"identity_token_audience": "test-aud",
+		"credentials":             credJson,
+	}
+
+	configReq = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   config.StorageView,
+		Path:      "config",
+		Data:      configData,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), configReq)
+	if err == nil {
+		t.Fatalf("expected an error but got nil")
+	}
+	expectedError := "only one of 'credentials' or 'identity_token_audience' can be set"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Fatalf("expected err %s, got %s", expectedError, resp.Error())
+	}
+
+	// erase storage so that no service account email is in config
+	config.StorageView = &logical.InmemStorage{}
+	// missing email with audience must result in an error
+	configData = map[string]interface{}{
+		"identity_token_audience": "test-aud",
+	}
+
+	configReq = &logical.Request{
+		Operation: logical.UpdateOperation,
+		Storage:   config.StorageView,
+		Path:      "config",
+		Data:      configData,
+	}
+
+	resp, err = b.HandleRequest(context.Background(), configReq)
+	if err == nil {
+		t.Fatalf("expected an error but got nil")
+	}
+	expectedError = "missing required 'service_account_email' when 'identity_token_audience' is set"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Fatalf("expected err %s, got %s", expectedError, resp.Error())
 	}
 }

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -36,8 +36,11 @@ func TestBackend_PathConfigRead(t *testing.T) {
 		if resp == nil {
 			t.Fatal("expected non-nil response")
 		}
-		if len(resp.Data) != 2 {
-			t.Fatal("expected 2 fields")
+		// These fields are always returned on read
+		// 2 Metadata response fields
+		// 2 Identity Token fields
+		if len(resp.Data) != 4 {
+			t.Fatal("expected 4 fields")
 		}
 		expectedResp := &logical.Response{
 			Data: map[string]interface{}{
@@ -58,6 +61,8 @@ func TestBackend_PathConfigRead(t *testing.T) {
 					"service_account_email",
 					"zone",
 				},
+				"identity_token_audience": "",
+				"identity_token_ttl":      int64(0),
 			},
 		}
 		if !reflect.DeepEqual(resp, expectedResp) {
@@ -134,6 +139,8 @@ func TestBackend_PathConfigRead(t *testing.T) {
 				"crm":     "https://cloudresourcemanager.example.com",
 				"compute": "https://compute.example.com",
 			},
+			"identity_token_audience": "",
+			"identity_token_ttl":      int64(0),
 		}
 
 		if !reflect.DeepEqual(resp.Data, expectedData) {

--- a/plugin/path_login.go
+++ b/plugin/path_login.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/go-secure-stdlib/strutil"


### PR DESCRIPTION
This PR adds plugin WIF support to the GCP auth engine. This adds the following new fields to the config endpoint to enable configuring Workload Identity Federation:

- `identity_token_audience`
- `identity_token_ttl`
- `service_account_email`

The PR adds the `PluginIdentityTokenSupplier` Credential Provider that fetches a plugin identity token from Vault and passes it to an external account Token Source for a valid federated credential exchange. The PR also pulls in the latest tag `v0.9.0` for the `go-gcp-common` library with WIF utils.