### PR TITLE
chore: bump and pin github actions

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # by default the checkout action doesn't check out all branches


### PR DESCRIPTION
Update actions and pin to prepare for node16 EOL