### PR TITLE
Forward Performance Standby requests when configuring root credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+## v0.20.2
+
 BUG FIXES:
 * Fix a panic when a performance standby node attempts to write/update config [GH-228](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/228)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+BUG FIXES:
+* Forward Performance Secondary Requests when configuring root credentials [GH-228](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/228)
+
 ## v0.20.1
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 BUG FIXES:
-* Forward Performance Secondary Requests when configuring root credentials [GH-228](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/228)
+* Fix a panic when a performance standby node attempts to write/update config [GH-228](https://github.com/hashicorp/vault-plugin-auth-gcp/pull/228)
 
 ## v0.20.1
 

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -119,6 +119,8 @@ Deprecated. This field does nothing and be removed in a future release`,
 					OperationVerb:   "configure",
 					OperationSuffix: "auth",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 		},
 


### PR DESCRIPTION
Fixes a bug where Performance Secondaries panic when they attempt to de-register / register jobs to the RM, since the RM is nil on Perf Secondaries. This fix appropriately forwards such requests to the Primary node in the cluster.