### PR TITLE
updates config display attrs

### DIFF
--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -73,19 +73,26 @@ func pathConfig(b *GcpAuthBackend) *framework.Path {
 Google credentials JSON that Vault will use to verify users against GCP APIs.
 If not specified, will use application default credentials`,
 				DisplayAttrs: &framework.DisplayAttributes{
-					Name: "Credentials",
+					Name:     "Credentials",
+					EditType: "file",
 				},
 			},
 			"iam_alias": {
 				Type:        framework.TypeString,
 				Default:     defaultIAMAlias,
 				Description: "Indicates what value to use when generating an alias for IAM authentications.",
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name: "IAM alias",
+				},
 			},
 			iamAuthMetadataFields.FieldName: authmetadata.FieldSchema(iamAuthMetadataFields),
 			"gce_alias": {
 				Type:        framework.TypeString,
 				Default:     defaultGCEAlias,
 				Description: "Indicates what value to use when generating an alias for GCE authentications.",
+				DisplayAttrs: &framework.DisplayAttributes{
+					Name: "GCE alias",
+				},
 			},
 			gceAuthMetadataFields.FieldName: authmetadata.FieldSchema(gceAuthMetadataFields),
 			"custom_endpoint": {


### PR DESCRIPTION
# Overview
This PR updates some display attrs which are used in the UI to dynamically render out the form for the the GCP auth config.

# Related Issues/Pull Requests
[PR #31499](https://github.com/hashicorp/vault/pull/31499)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
